### PR TITLE
EventRegistrationToken.Value is nonzero when valid

### DIFF
--- a/windows.foundation/eventregistrationtoken.md
+++ b/windows.foundation/eventregistrationtoken.md
@@ -21,7 +21,7 @@ Represents a reference to a delegate that receives change notifications.
 
 ### -field Value
 The reference to the delegate.
-    
+A valid reference will not have a value of zero.
 
 ## -remarks
 When programming with .NET, this type is hidden and developers that need an event registration token for advanced event scenarios should use the [System.Runtime.InteropServices.WindowsRuntime.EventRegistrationToken](https://msdn.microsoft.com/library/system.runtime.interopservices.windowsruntime.eventregistrationtoken.aspx) type. For most app code, you won't need [EventRegistrationToken](https://msdn.microsoft.com/library/system.runtime.interopservices.windowsruntime.eventregistrationtoken.aspx) (or event registration tokens) at all, because the add/remove syntax for C# and Visual Basic languages enables the compiler to generate the registration tokens from a simpler syntax.


### PR DESCRIPTION
The value of 0 is reserved and does not represent a valid reference. Applications can use 0 as a sentinel value for tokens that are not actively referencing a delegate.