### PR TITLE
JsonObject methods that accept a default value will not throw

### DIFF
--- a/windows.data.json/jsonobject_getnamedarray_1738038789.md
+++ b/windows.data.json/jsonobject_getnamedarray_1738038789.md
@@ -23,7 +23,6 @@ The default value to use if the JSON property is not found.
 The [JsonArray](jsonarray.md) with the specified *name*, or if this value wasn't found, the *defaultValue* is returned.
 
 ## -remarks
-This method should always used with a try/catch block because it throws an exception if the name is not found.
 
 ## -examples
 

--- a/windows.data.json/jsonobject_getnamedboolean_1472935654.md
+++ b/windows.data.json/jsonobject_getnamedboolean_1472935654.md
@@ -23,7 +23,6 @@ The default value to use if the JSON property is not found.
 The [Boolean](https://msdn.microsoft.com/library/system.boolean.aspx) with the specified *name*, or if this value wasn't found, the *defaultValue* is returned.
 
 ## -remarks
-This method should always used with a try/catch block because it throws an exception if the name is not found.
 
 ## -examples
 

--- a/windows.data.json/jsonobject_getnamednumber_124311229.md
+++ b/windows.data.json/jsonobject_getnamednumber_124311229.md
@@ -23,7 +23,6 @@ The default value to use if the JSON property is not found.
 The [Double](https://msdn.microsoft.com/library/system.double.aspx) with the specified *name*, or if this value wasn't found, the *defaultValue* is returned.
 
 ## -remarks
-This method should always used with a try/catch block because it throws an exception if the name is not found.
 
 ## -examples
 

--- a/windows.data.json/jsonobject_getnamedobject_1279840399.md
+++ b/windows.data.json/jsonobject_getnamedobject_1279840399.md
@@ -23,7 +23,6 @@ The default value to use if the JSON property is not found.
 The [JsonObject](jsonobject.md) with the specified *name*, or if this value wasn't found, the *defaultValue* is returned.
 
 ## -remarks
-This method should always used with a try/catch block because it throws an exception if the name is not found.
 
 ## -examples
 

--- a/windows.data.json/jsonobject_getnamedstring_1418463848.md
+++ b/windows.data.json/jsonobject_getnamedstring_1418463848.md
@@ -23,7 +23,6 @@ The default value to use if the JSON property is not found.
 The [String](https://msdn.microsoft.com/library/system.string.aspx) with the specified *name*, or if this value wasn't found, the *defaultValue* is returned.
 
 ## -remarks
-This method should always used with a try/catch block because it throws an exception if the name is not found.
 
 ## -examples
 

--- a/windows.data.json/jsonobject_getnamedvalue_1852490180.md
+++ b/windows.data.json/jsonobject_getnamedvalue_1852490180.md
@@ -23,7 +23,6 @@ The default value to use if the JSON property is not found.
 The [JsonValue](jsonvalue.md) with the specified *name*, or if this value wasn't found, the *defaultValue* is returned.
 
 ## -remarks
-This method should always used with a try/catch block because it throws an exception if the name is not found.
 
 ## -examples
 


### PR DESCRIPTION
GetNamedValue and similar methods in Windows.Data.JsonObject have overloads which take a default value as a parameter. If the named value is not found, the default value will be returned. Remove remarks which suggest that an exception will be thrown in this case.