### PR TITLE
Update applicationviewswitcher_tryshowasviewmodeasync_729393684.md

### DIFF
--- a/windows.ui.viewmanagement/applicationviewswitcher_tryshowasviewmodeasync_729393684.md
+++ b/windows.ui.viewmanagement/applicationviewswitcher_tryshowasviewmodeasync_729393684.md
@@ -27,6 +27,9 @@ Preferred settings for the desired view mode.
 Asynchronously returns **true** if the call succeeds; **false** if it does not.
 
 ## -remarks
+If this method succeeds, a new window is created next to the original window. It can only be called from an ASTA (core UI) thread.
+
+The new window has its own UI thread (ASTA) and associated [CoreWindow](../windows.ui.core/corewindow.md). Developers should use thread-safe methods for communication between the windows, such as **window.postMessage** for JavaScript apps and the [CoreDispatcher](../windows.ui.core/coredispatcher.md) ([CoreWindow.Dispatcher](../windows.ui.core/corewindow_dispatcher.md)) messaging for C# and C++ developers.
 
 ## -see-also
 


### PR DESCRIPTION
The TryShowAsViewModeAsync methods should have the same remark as the TryShowAsStandaloneAsync since they also create a new window with its own ASTA.