### PR TITLE
Update textbox_textalignment.md

### DIFF
--- a/windows.ui.xaml.controls/textbox_textalignment.md
+++ b/windows.ui.xaml.controls/textbox_textalignment.md
@@ -10,7 +10,7 @@ public Windows.UI.Xaml.TextAlignment TextAlignment { get;  set; }
 # Windows.UI.Xaml.Controls.TextBox.TextAlignment
 
 ## -description
-Gets or sets how the text should be aligned in the text box.
+Gets or sets how the text should be horizontally aligned in the text box.
 
 ## -xaml-syntax
 ```xaml


### PR DESCRIPTION
Make it clearer that TextAlignment property can only be used for horizontal alignment without needing to look at enum.