### PR TITLE
Fixup Input Method Editor (IME) references

### DIFF
--- a/windows.ui.core/acceleratorkeyeventargs.md
+++ b/windows.ui.core/acceleratorkeyeventargs.md
@@ -16,7 +16,7 @@ Provides the arguments returned by an accelerator key event callback.
 
 
 > **Windows 10**
-> Apps do not receive this event when an [](http://msdn.microsoft.com/library/5fcc73e6-f499-47e6-8e81-0014ca4d241c) is enabled. The Input Method Editor (IME) handles all keyboard input and sets [Handled](acceleratorkeyeventargs_handled.md) to **true**.
+> Apps do not receive this event when an [Input Method Editor (IME)](http://msdn.microsoft.com/library/5fcc73e6-f499-47e6-8e81-0014ca4d241c) is enabled. The Input Method Editor (IME) handles all keyboard input and sets [Handled](acceleratorkeyeventargs_handled.md) to **true**.
 
 
 

--- a/windows.ui.core/acceleratorkeyeventargs_handled.md
+++ b/windows.ui.core/acceleratorkeyeventargs_handled.md
@@ -17,7 +17,7 @@ True if the accelerator key event has been handled; false if it has not.
 
 ## -remarks
 > **Windows 10**
-> Apps do not receive this event when an [](http://msdn.microsoft.com/library/5fcc73e6-f499-47e6-8e81-0014ca4d241c) is enabled. The Input Method Editor (IME) handles all keyboard input and sets [Handled](acceleratorkeyeventargs_handled.md) to **true**.
+> Apps do not receive this event when an [Input Method Editor (IME)](http://msdn.microsoft.com/library/5fcc73e6-f499-47e6-8e81-0014ca4d241c) is enabled. The Input Method Editor (IME) handles all keyboard input and sets [Handled](acceleratorkeyeventargs_handled.md) to **true**.
 
 > **Windows Phone**
 > This API is supported in native apps only.

--- a/windows.ui.core/characterreceivedeventargs.md
+++ b/windows.ui.core/characterreceivedeventargs.md
@@ -16,7 +16,7 @@ Provides the arguments returned by the event raised when a character is received
 
 
 > **Windows 10**
-> Apps do not receive this event when an [](http://msdn.microsoft.com/library/5fcc73e6-f499-47e6-8e81-0014ca4d241c) is enabled. The Input Method Editor (IME) handles all keyboard input and sets [Handled](acceleratorkeyeventargs_handled.md) to **true**.
+> Apps do not receive this event when an [Input Method Editor (IME)](http://msdn.microsoft.com/library/5fcc73e6-f499-47e6-8e81-0014ca4d241c) is enabled. The Input Method Editor (IME) handles all keyboard input and sets [Handled](acceleratorkeyeventargs_handled.md) to **true**.
 
 
 

--- a/windows.ui.core/characterreceivedeventargs_handled.md
+++ b/windows.ui.core/characterreceivedeventargs_handled.md
@@ -17,7 +17,7 @@ True if the character received event has been handled; false if it has not.
 
 ## -remarks
 > **Windows 10**
-> Apps do not receive this event when an [](http://msdn.microsoft.com/library/5fcc73e6-f499-47e6-8e81-0014ca4d241c) is enabled. The Input Method Editor (IME) handles all keyboard input and sets [Handled](characterreceivedeventargs_handled.md) to **true**.
+> Apps do not receive this event when an [Input Method Editor (IME)](http://msdn.microsoft.com/library/5fcc73e6-f499-47e6-8e81-0014ca4d241c) is enabled. The Input Method Editor (IME) handles all keyboard input and sets [Handled](characterreceivedeventargs_handled.md) to **true**.
 
 > **Windows Phone**
 > This API is supported in native apps only.

--- a/windows.ui.core/characterreceivedeventargs_keycode.md
+++ b/windows.ui.core/characterreceivedeventargs_keycode.md
@@ -17,7 +17,7 @@ The key code of the character received by the input queue.
 
 ## -remarks
 > **Windows 10**
-> Apps do not receive this event when an [](http://msdn.microsoft.com/library/5fcc73e6-f499-47e6-8e81-0014ca4d241c) is enabled. The Input Method Editor (IME) handles all keyboard input and sets [Handled](characterreceivedeventargs_handled.md) to **true**.
+> Apps do not receive this event when an [Input Method Editor (IME)](http://msdn.microsoft.com/library/5fcc73e6-f499-47e6-8e81-0014ca4d241c) is enabled. The Input Method Editor (IME) handles all keyboard input and sets [Handled](characterreceivedeventargs_handled.md) to **true**.
 
 > **Windows Phone**
 > This API is supported in native apps only.

--- a/windows.ui.core/characterreceivedeventargs_keystatus.md
+++ b/windows.ui.core/characterreceivedeventargs_keystatus.md
@@ -17,7 +17,7 @@ The status of the key that was pressed.
 
 ## -remarks
 > **Windows 10**
-> Apps do not receive this event when an [](http://msdn.microsoft.com/library/5fcc73e6-f499-47e6-8e81-0014ca4d241c) is enabled. The Input Method Editor (IME) handles all keyboard input and sets [Handled](characterreceivedeventargs_handled.md) to **true**.
+> Apps do not receive this event when an [Input Method Editor (IME)](http://msdn.microsoft.com/library/5fcc73e6-f499-47e6-8e81-0014ca4d241c) is enabled. The Input Method Editor (IME) handles all keyboard input and sets [Handled](characterreceivedeventargs_handled.md) to **true**.
 
 > **Windows Phone**
 > This API is supported in native apps only.

--- a/windows.ui.core/coreacceleratorkeys_acceleratorkeyactivated.md
+++ b/windows.ui.core/coreacceleratorkeys_acceleratorkeyactivated.md
@@ -16,7 +16,7 @@ Fired when an accelerator key is pressed or activated.
 
 
 > **Windows 10**
-> Apps do not receive this event when an [](http://msdn.microsoft.com/library/5fcc73e6-f499-47e6-8e81-0014ca4d241c) is enabled. The Input Method Editor (IME) handles all keyboard input and sets [Handled](acceleratorkeyeventargs_handled.md) to **true**.
+> Apps do not receive this event when an [Input Method Editor (IME)](http://msdn.microsoft.com/library/5fcc73e6-f499-47e6-8e81-0014ca4d241c) is enabled. The Input Method Editor (IME) handles all keyboard input and sets [Handled](acceleratorkeyeventargs_handled.md) to **true**.
 
 
 

--- a/windows.ui.core/corewindow_characterreceived.md
+++ b/windows.ui.core/corewindow_characterreceived.md
@@ -13,7 +13,7 @@ public event Windows.Foundation.TypedEventHandler CharacterReceived<Windows.UI.C
 Is fired when a new character is received by the input queue.
 
 ## -remarks
-Apps do not receive this event when an [](http://msdn.microsoft.com/library/5fcc73e6-f499-47e6-8e81-0014ca4d241c) is enabled. The Input Method Editor (IME) handles all keyboard input and sets [Handled](characterreceivedeventargs_handled.md) to **true**.
+Apps do not receive this event when an [Input Method Editor (IME)](http://msdn.microsoft.com/library/5fcc73e6-f499-47e6-8e81-0014ca4d241c) is enabled. The Input Method Editor (IME) handles all keyboard input and sets [Handled](characterreceivedeventargs_handled.md) to **true**.
 
 ## -examples
 

--- a/windows.ui.core/corewindow_keydown.md
+++ b/windows.ui.core/corewindow_keydown.md
@@ -13,7 +13,7 @@ public event Windows.Foundation.TypedEventHandler KeyDown<Windows.UI.Core.CoreWi
 Is fired when a non-system key is pressed.
 
 ## -remarks
-Apps do not receive this event when an [](http://msdn.microsoft.com/library/5fcc73e6-f499-47e6-8e81-0014ca4d241c) is enabled. The Input Method Editor (IME) handles all keyboard input and sets [Handled](keyeventargs_handled.md) to **true**.
+Apps do not receive this event when an [Input Method Editor (IME)](http://msdn.microsoft.com/library/5fcc73e6-f499-47e6-8e81-0014ca4d241c) is enabled. The Input Method Editor (IME) handles all keyboard input and sets [Handled](keyeventargs_handled.md) to **true**.
 
 ## -examples
 

--- a/windows.ui.core/keyeventargs.md
+++ b/windows.ui.core/keyeventargs.md
@@ -16,7 +16,7 @@ Contains the arguments returned by a virtual key event.
 
 
 > **Windows 10**
-> Apps do not receive this event when an [](http://msdn.microsoft.com/library/5fcc73e6-f499-47e6-8e81-0014ca4d241c) is enabled. The Input Method Editor (IME) handles all keyboard input and sets [Handled](keyeventargs_handled.md) to **true**.
+> Apps do not receive this event when an [Input Method Editor (IME)](http://msdn.microsoft.com/library/5fcc73e6-f499-47e6-8e81-0014ca4d241c) is enabled. The Input Method Editor (IME) handles all keyboard input and sets [Handled](keyeventargs_handled.md) to **true**.
 
 
 

--- a/windows.ui.core/keyeventargs_handled.md
+++ b/windows.ui.core/keyeventargs_handled.md
@@ -17,7 +17,7 @@ True if the key press event has been handled by the appropriate delegate; false 
 
 ## -remarks
 > **Windows 10**
-> Apps do not receive this event when an [](http://msdn.microsoft.com/library/5fcc73e6-f499-47e6-8e81-0014ca4d241c) is enabled. The Input Method Editor (IME) handles all keyboard input and sets [Handled](keyeventargs_handled.md) to **true**.
+> Apps do not receive this event when an [Input Method Editor (IME)](http://msdn.microsoft.com/library/5fcc73e6-f499-47e6-8e81-0014ca4d241c) is enabled. The Input Method Editor (IME) handles all keyboard input and sets [Handled](keyeventargs_handled.md) to **true**.
 
 > **Windows Phone**
 > This API is supported in native apps only.

--- a/windows.ui.core/keyeventargs_keystatus.md
+++ b/windows.ui.core/keyeventargs_keystatus.md
@@ -17,7 +17,7 @@ The status of the key.
 
 ## -remarks
 > **Windows 10**
-> Apps do not receive this event when an [](http://msdn.microsoft.com/library/5fcc73e6-f499-47e6-8e81-0014ca4d241c) is enabled. The Input Method Editor (IME) handles all keyboard input and sets [Handled](keyeventargs_handled.md) to **true**.
+> Apps do not receive this event when an [Input Method Editor (IME)](http://msdn.microsoft.com/library/5fcc73e6-f499-47e6-8e81-0014ca4d241c) is enabled. The Input Method Editor (IME) handles all keyboard input and sets [Handled](keyeventargs_handled.md) to **true**.
 
 > **Windows Phone**
 > This API is supported in native apps only.

--- a/windows.ui.core/keyeventargs_virtualkey.md
+++ b/windows.ui.core/keyeventargs_virtualkey.md
@@ -17,7 +17,7 @@ The virtual key value.
 
 ## -remarks
 > **Windows 10**
-> Apps do not receive this event when an [](http://msdn.microsoft.com/library/5fcc73e6-f499-47e6-8e81-0014ca4d241c) is enabled. The Input Method Editor (IME) handles all keyboard input and sets [Handled](keyeventargs_handled.md) to **true**.
+> Apps do not receive this event when an [Input Method Editor (IME)](http://msdn.microsoft.com/library/5fcc73e6-f499-47e6-8e81-0014ca4d241c) is enabled. The Input Method Editor (IME) handles all keyboard input and sets [Handled](keyeventargs_handled.md) to **true**.
 
 > **Windows Phone**
 > This API is supported in native apps only.

--- a/windows.ui.xaml.controls/richeditbox_textcompositionchanged.md
+++ b/windows.ui.xaml.controls/richeditbox_textcompositionchanged.md
@@ -15,7 +15,7 @@ Occurs when text being composed through an Input Method Editor (IME) changes.
 ## -remarks
 For event data, see [TextCompositionChangedEventArgs](textcompositionchangedeventargs.md).
 
-This event occurs only when text is composed through an [](http://msdn.microsoft.com/library/5fcc73e6-f499-47e6-8e81-0014ca4d241c). Text composition events occur in the following order:
+This event occurs only when text is composed through an [Input Method Editor (IME)](http://msdn.microsoft.com/library/5fcc73e6-f499-47e6-8e81-0014ca4d241c). Text composition events occur in the following order:
 + [TextCompositionStarted](richeditbox_textcompositionstarted.md)
 + [TextChanging](richeditbox_textchanging.md)
 + [TextChanged](richeditbox_textchanged.md)
@@ -30,4 +30,4 @@ After the [TextCompositionStarted](richeditbox_textcompositionstarted.md) event,
 ## -examples
 
 ## -see-also
-[TextCompositionChangedEventArgs](textcompositionchangedeventargs.md), [](http://msdn.microsoft.com/library/5fcc73e6-f499-47e6-8e81-0014ca4d241c)
+[TextCompositionChangedEventArgs](textcompositionchangedeventargs.md), [Input Method Editor (IME)](http://msdn.microsoft.com/library/5fcc73e6-f499-47e6-8e81-0014ca4d241c)

--- a/windows.ui.xaml.controls/richeditbox_textcompositionended.md
+++ b/windows.ui.xaml.controls/richeditbox_textcompositionended.md
@@ -15,7 +15,7 @@ Occurs when a user stops composing text through an Input Method Editor (IME).
 ## -remarks
 For event data, see [TextCompositionEndedEventArgs](textcompositionendedeventargs.md).
 
-This event occurs only when text is composed through an [](http://msdn.microsoft.com/library/5fcc73e6-f499-47e6-8e81-0014ca4d241c). Text composition events occur in the following order:
+This event occurs only when text is composed through an [Input Method Editor (IME)](http://msdn.microsoft.com/library/5fcc73e6-f499-47e6-8e81-0014ca4d241c). Text composition events occur in the following order:
 + [TextCompositionStarted](richeditbox_textcompositionstarted.md)
 + [TextChanging](richeditbox_textchanging.md)
 + [TextChanged](richeditbox_textchanged.md)
@@ -30,4 +30,4 @@ After the [TextCompositionStarted](richeditbox_textcompositionstarted.md) event,
 ## -examples
 
 ## -see-also
-[TextCompositionEndedEventArgs](textcompositionendedeventargs.md), [](http://msdn.microsoft.com/library/5fcc73e6-f499-47e6-8e81-0014ca4d241c)
+[TextCompositionEndedEventArgs](textcompositionendedeventargs.md), [Input Method Editor (IME)](http://msdn.microsoft.com/library/5fcc73e6-f499-47e6-8e81-0014ca4d241c)

--- a/windows.ui.xaml.controls/richeditbox_textcompositionstarted.md
+++ b/windows.ui.xaml.controls/richeditbox_textcompositionstarted.md
@@ -15,7 +15,7 @@ Occurs when a user starts composing text through an Input Method Editor (IME).
 ## -remarks
 For event data, see [TextCompositionStartedEventArgs](textcompositionstartedeventargs.md).
 
-This event occurs only when text is composed through an [](http://msdn.microsoft.com/library/5fcc73e6-f499-47e6-8e81-0014ca4d241c). Text composition events occur in the following order:
+This event occurs only when text is composed through an [Input Method Editor (IME)](http://msdn.microsoft.com/library/5fcc73e6-f499-47e6-8e81-0014ca4d241c). Text composition events occur in the following order:
 + [TextCompositionStarted](richeditbox_textcompositionstarted.md)
 + [TextChanging](richeditbox_textchanging.md)
 + [TextChanged](richeditbox_textchanged.md)
@@ -30,4 +30,4 @@ After the [TextCompositionStarted](richeditbox_textcompositionstarted.md) event,
 ## -examples
 
 ## -see-also
-[TextCompositionStartedEventArgs](textcompositionstartedeventargs.md), [](http://msdn.microsoft.com/library/5fcc73e6-f499-47e6-8e81-0014ca4d241c)
+[TextCompositionStartedEventArgs](textcompositionstartedeventargs.md), [Input Method Editor (IME)](http://msdn.microsoft.com/library/5fcc73e6-f499-47e6-8e81-0014ca4d241c)

--- a/windows.ui.xaml.controls/textbox_textcompositionchanged.md
+++ b/windows.ui.xaml.controls/textbox_textcompositionchanged.md
@@ -15,7 +15,7 @@ Occurs when text being composed through an Input Method Editor (IME) changes.
 ## -remarks
 For event data, see [TextCompositionChangedEventArgs](textcompositionchangedeventargs.md).
 
-This event occurs only when text is composed through an [](http://msdn.microsoft.com/library/5fcc73e6-f499-47e6-8e81-0014ca4d241c). Text composition events occur in the following order:
+This event occurs only when text is composed through an [Input Method Editor (IME)](http://msdn.microsoft.com/library/5fcc73e6-f499-47e6-8e81-0014ca4d241c). Text composition events occur in the following order:
 + [TextCompositionStarted](textbox_textcompositionstarted.md)
 + [TextChanging](textbox_textchanging.md)
 + [TextChanged](textbox_textchanged.md)
@@ -30,4 +30,4 @@ After the [TextCompositionStarted](textbox_textcompositionstarted.md) event, the
 ## -examples
 
 ## -see-also
-[TextCompositionChangedEventArgs](textcompositionchangedeventargs.md), [](http://msdn.microsoft.com/library/5fcc73e6-f499-47e6-8e81-0014ca4d241c)
+[TextCompositionChangedEventArgs](textcompositionchangedeventargs.md), [Input Method Editor (IME)](http://msdn.microsoft.com/library/5fcc73e6-f499-47e6-8e81-0014ca4d241c)

--- a/windows.ui.xaml.controls/textbox_textcompositionended.md
+++ b/windows.ui.xaml.controls/textbox_textcompositionended.md
@@ -15,7 +15,7 @@ Occurs when a user stops composing text through an Input Method Editor (IME).
 ## -remarks
 For event data, see [TextCompositionEndedEventArgs](textcompositionendedeventargs.md).
 
-This event occurs only when text is composed through an [](http://msdn.microsoft.com/library/5fcc73e6-f499-47e6-8e81-0014ca4d241c). Text composition events occur in the following order:
+This event occurs only when text is composed through an [Input Method Editor (IME)](http://msdn.microsoft.com/library/5fcc73e6-f499-47e6-8e81-0014ca4d241c). Text composition events occur in the following order:
 + [TextCompositionStarted](textbox_textcompositionstarted.md)
 + [TextChanging](textbox_textchanging.md)
 + [TextChanged](textbox_textchanged.md)
@@ -30,4 +30,4 @@ After the [TextCompositionStarted](textbox_textcompositionstarted.md) event, the
 ## -examples
 
 ## -see-also
-[TextCompositionEndedEventArgs](textcompositionendedeventargs.md), [](http://msdn.microsoft.com/library/5fcc73e6-f499-47e6-8e81-0014ca4d241c)
+[TextCompositionEndedEventArgs](textcompositionendedeventargs.md), [Input Method Editor (IME)](http://msdn.microsoft.com/library/5fcc73e6-f499-47e6-8e81-0014ca4d241c)

--- a/windows.ui.xaml.controls/textbox_textcompositionstarted.md
+++ b/windows.ui.xaml.controls/textbox_textcompositionstarted.md
@@ -15,7 +15,7 @@ Occurs when a user starts composing text through an Input Method Editor (IME).
 ## -remarks
 For event data, see [TextCompositionStartedEventArgs](textcompositionstartedeventargs.md).
 
-This event occurs only when text is composed through an [](http://msdn.microsoft.com/library/5fcc73e6-f499-47e6-8e81-0014ca4d241c). Text composition events occur in the following order:
+This event occurs only when text is composed through an [Input Method Editor (IME)](http://msdn.microsoft.com/library/5fcc73e6-f499-47e6-8e81-0014ca4d241c). Text composition events occur in the following order:
 + [TextCompositionStarted](textbox_textcompositionstarted.md)
 + [TextChanging](textbox_textchanging.md)
 + [TextChanged](textbox_textchanged.md)
@@ -30,4 +30,4 @@ After the [TextCompositionStarted](textbox_textcompositionstarted.md) event, the
 ## -examples
 
 ## -see-also
-[TextCompositionStartedEventArgs](textcompositionstartedeventargs.md), [](http://msdn.microsoft.com/library/5fcc73e6-f499-47e6-8e81-0014ca4d241c)
+[TextCompositionStartedEventArgs](textcompositionstartedeventargs.md), [Input Method Editor (IME)](http://msdn.microsoft.com/library/5fcc73e6-f499-47e6-8e81-0014ca4d241c)

--- a/windows.ui.xaml.controls/textcompositionchangedeventargs.md
+++ b/windows.ui.xaml.controls/textcompositionchangedeventargs.md
@@ -18,4 +18,4 @@ For more info, see the [TextBox.TextCompositionChanged](textbox_textcompositionc
 ## -examples
 
 ## -see-also
-[TextBox.TextCompositionChanged](textbox_textcompositionchanged.md), [RichEditBox.TextCompositionChanged](richeditbox_textcompositionchanged.md), [](http://msdn.microsoft.com/library/5fcc73e6-f499-47e6-8e81-0014ca4d241c)
+[TextBox.TextCompositionChanged](textbox_textcompositionchanged.md), [RichEditBox.TextCompositionChanged](richeditbox_textcompositionchanged.md), [Input Method Editor (IME)](http://msdn.microsoft.com/library/5fcc73e6-f499-47e6-8e81-0014ca4d241c)

--- a/windows.ui.xaml.controls/textcompositionchangedeventargs_length.md
+++ b/windows.ui.xaml.controls/textcompositionchangedeventargs_length.md
@@ -13,11 +13,11 @@ public int Length { get; }
 Gets the length of the portion of the text that the user is composing with an Input Method Editor (IME).
 
 ## -property-value
-The length of the portion of the text that the user is composing with an [](http://msdn.microsoft.com/library/5fcc73e6-f499-47e6-8e81-0014ca4d241c).
+The length of the portion of the text that the user is composing with an [Input Method Editor (IME)](http://msdn.microsoft.com/library/5fcc73e6-f499-47e6-8e81-0014ca4d241c).
 
 ## -remarks
 
 ## -examples
 
 ## -see-also
-[TextBox.TextCompositionChanged](textbox_textcompositionchanged.md), [RichEditBox.TextCompositionChanged](richeditbox_textcompositionchanged.md), [](http://msdn.microsoft.com/library/5fcc73e6-f499-47e6-8e81-0014ca4d241c)
+[TextBox.TextCompositionChanged](textbox_textcompositionchanged.md), [RichEditBox.TextCompositionChanged](richeditbox_textcompositionchanged.md), [Input Method Editor (IME)](http://msdn.microsoft.com/library/5fcc73e6-f499-47e6-8e81-0014ca4d241c)

--- a/windows.ui.xaml.controls/textcompositionchangedeventargs_startindex.md
+++ b/windows.ui.xaml.controls/textcompositionchangedeventargs_startindex.md
@@ -13,11 +13,11 @@ public int StartIndex { get; }
 Gets the starting location of the text that the user is composing with an Input Method Editor (IME).
 
 ## -property-value
-The starting location of the text that the user is composing with an [](http://msdn.microsoft.com/library/5fcc73e6-f499-47e6-8e81-0014ca4d241c).
+The starting location of the text that the user is composing with an [Input Method Editor (IME)](http://msdn.microsoft.com/library/5fcc73e6-f499-47e6-8e81-0014ca4d241c).
 
 ## -remarks
 
 ## -examples
 
 ## -see-also
-[TextBox.TextCompositionChanged](textbox_textcompositionchanged.md), [RichEditBox.TextCompositionChanged](richeditbox_textcompositionchanged.md), [](http://msdn.microsoft.com/library/5fcc73e6-f499-47e6-8e81-0014ca4d241c)
+[TextBox.TextCompositionChanged](textbox_textcompositionchanged.md), [RichEditBox.TextCompositionChanged](richeditbox_textcompositionchanged.md), [Input Method Editor (IME)](http://msdn.microsoft.com/library/5fcc73e6-f499-47e6-8e81-0014ca4d241c)

--- a/windows.ui.xaml.controls/textcompositionendedeventargs.md
+++ b/windows.ui.xaml.controls/textcompositionendedeventargs.md
@@ -18,4 +18,4 @@ For more info, see the [TextBox.TextCompositionEnded](textbox_textcompositionend
 ## -examples
 
 ## -see-also
-[TextBox.TextCompositionEnded](textbox_textcompositionended.md), [RichEditBox.TextCompositionEnded](richeditbox_textcompositionended.md), [](http://msdn.microsoft.com/library/5fcc73e6-f499-47e6-8e81-0014ca4d241c)
+[TextBox.TextCompositionEnded](textbox_textcompositionended.md), [RichEditBox.TextCompositionEnded](richeditbox_textcompositionended.md), [Input Method Editor (IME)](http://msdn.microsoft.com/library/5fcc73e6-f499-47e6-8e81-0014ca4d241c)

--- a/windows.ui.xaml.controls/textcompositionendedeventargs_length.md
+++ b/windows.ui.xaml.controls/textcompositionendedeventargs_length.md
@@ -13,11 +13,11 @@ public int Length { get; }
 Gets the length of the portion of the text that the user is composing with an Input Method Editor (IME).
 
 ## -property-value
-The length of the portion of the text that the user is composing with an [](http://msdn.microsoft.com/library/5fcc73e6-f499-47e6-8e81-0014ca4d241c).
+The length of the portion of the text that the user is composing with an [Input Method Editor (IME)](http://msdn.microsoft.com/library/5fcc73e6-f499-47e6-8e81-0014ca4d241c).
 
 ## -remarks
 
 ## -examples
 
 ## -see-also
-[TextBox.TextCompositionEnded](textbox_textcompositionended.md), [RichEditBox.TextCompositionEnded](richeditbox_textcompositionended.md), [](http://msdn.microsoft.com/library/5fcc73e6-f499-47e6-8e81-0014ca4d241c)
+[TextBox.TextCompositionEnded](textbox_textcompositionended.md), [RichEditBox.TextCompositionEnded](richeditbox_textcompositionended.md), [Input Method Editor (IME)](http://msdn.microsoft.com/library/5fcc73e6-f499-47e6-8e81-0014ca4d241c)

--- a/windows.ui.xaml.controls/textcompositionendedeventargs_startindex.md
+++ b/windows.ui.xaml.controls/textcompositionendedeventargs_startindex.md
@@ -13,11 +13,11 @@ public int StartIndex { get; }
 Gets the starting location of the text that the user is composing with an Input Method Editor (IME).
 
 ## -property-value
-The starting location of the text that the user is composing with an [](http://msdn.microsoft.com/library/5fcc73e6-f499-47e6-8e81-0014ca4d241c).
+The starting location of the text that the user is composing with an [Input Method Editor (IME)](http://msdn.microsoft.com/library/5fcc73e6-f499-47e6-8e81-0014ca4d241c).
 
 ## -remarks
 
 ## -examples
 
 ## -see-also
-[TextBox.TextCompositionEnded](textbox_textcompositionended.md), [RichEditBox.TextCompositionEnded](richeditbox_textcompositionended.md), [](http://msdn.microsoft.com/library/5fcc73e6-f499-47e6-8e81-0014ca4d241c)
+[TextBox.TextCompositionEnded](textbox_textcompositionended.md), [RichEditBox.TextCompositionEnded](richeditbox_textcompositionended.md), [Input Method Editor (IME)](http://msdn.microsoft.com/library/5fcc73e6-f499-47e6-8e81-0014ca4d241c)

--- a/windows.ui.xaml.controls/textcompositionstartedeventargs.md
+++ b/windows.ui.xaml.controls/textcompositionstartedeventargs.md
@@ -18,4 +18,4 @@ For more info, see the [TextBox.TextCompositionStarted](textbox_textcompositions
 ## -examples
 
 ## -see-also
-[TextBox.TextCompositionStarted](textbox_textcompositionstarted.md), [RichEditBox.TextCompositionStarted](richeditbox_textcompositionstarted.md), [](http://msdn.microsoft.com/library/5fcc73e6-f499-47e6-8e81-0014ca4d241c)
+[TextBox.TextCompositionStarted](textbox_textcompositionstarted.md), [RichEditBox.TextCompositionStarted](richeditbox_textcompositionstarted.md), [Input Method Editor (IME)](http://msdn.microsoft.com/library/5fcc73e6-f499-47e6-8e81-0014ca4d241c)

--- a/windows.ui.xaml.controls/textcompositionstartedeventargs_length.md
+++ b/windows.ui.xaml.controls/textcompositionstartedeventargs_length.md
@@ -13,11 +13,11 @@ public int Length { get; }
 Gets the length of the portion of the text that the user is composing with an Input Method Editor (IME).
 
 ## -property-value
-The length of the portion of the text that the user is composing with an [](http://msdn.microsoft.com/library/5fcc73e6-f499-47e6-8e81-0014ca4d241c).
+The length of the portion of the text that the user is composing with an [Input Method Editor (IME)](http://msdn.microsoft.com/library/5fcc73e6-f499-47e6-8e81-0014ca4d241c).
 
 ## -remarks
 
 ## -examples
 
 ## -see-also
-[TextBox.TextCompositionStarted](textbox_textcompositionstarted.md), [RichEditBox.TextCompositionStarted](richeditbox_textcompositionstarted.md), [](http://msdn.microsoft.com/library/5fcc73e6-f499-47e6-8e81-0014ca4d241c)
+[TextBox.TextCompositionStarted](textbox_textcompositionstarted.md), [RichEditBox.TextCompositionStarted](richeditbox_textcompositionstarted.md), [Input Method Editor (IME)](http://msdn.microsoft.com/library/5fcc73e6-f499-47e6-8e81-0014ca4d241c)

--- a/windows.ui.xaml.controls/textcompositionstartedeventargs_startindex.md
+++ b/windows.ui.xaml.controls/textcompositionstartedeventargs_startindex.md
@@ -13,11 +13,11 @@ public int StartIndex { get; }
 Gets the starting location of the text that the user is composing with an Input Method Editor (IME).
 
 ## -property-value
-The starting location of the text that the user is composing with an [](http://msdn.microsoft.com/library/5fcc73e6-f499-47e6-8e81-0014ca4d241c).
+The starting location of the text that the user is composing with an [Input Method Editor (IME)](http://msdn.microsoft.com/library/5fcc73e6-f499-47e6-8e81-0014ca4d241c).
 
 ## -remarks
 
 ## -examples
 
 ## -see-also
-[TextBox.TextCompositionStarted](textbox_textcompositionstarted.md), [RichEditBox.TextCompositionStarted](richeditbox_textcompositionstarted.md), [](http://msdn.microsoft.com/library/5fcc73e6-f499-47e6-8e81-0014ca4d241c)
+[TextBox.TextCompositionStarted](textbox_textcompositionstarted.md), [RichEditBox.TextCompositionStarted](richeditbox_textcompositionstarted.md), [Input Method Editor (IME)](http://msdn.microsoft.com/library/5fcc73e6-f499-47e6-8e81-0014ca4d241c)


### PR DESCRIPTION
Fixes a bunch of blank MSDN IME references that led to confusing statements, such as:
> Apps do not receive this event when an is enabled. The Input Method Editor (IME) handles all keyboard input and sets Handled to true.