### PR TITLE
Clarify properties that can be used

### DIFF
--- a/windows.storage.search/contentindexer.md
+++ b/windows.storage.search/contentindexer.md
@@ -15,7 +15,7 @@ Enables Windows Store app to place content properties in the system index.
 ## -remarks
 The index is a cache of searchable properties for data that's backed by storage elsewhere. Don't use the index as a primary data store.
 
-Define properties for the index with string-object key-value pairs, where the keys are standard Windows property names, like [System.Author](https://msdn.microsoft.com/library/windows/desktop/bb760652.aspx), and the values are [PropertyValue](../windows.foundation/propertyvalue.md) instances. The property must be registered on the system.
+Define properties for the index with string-object key-value pairs, where the keys are standard Windows property names, like [System.Author](https://msdn.microsoft.com/library/windows/desktop/bb760652.aspx), and the values are [PropertyValue](../windows.foundation/propertyvalue.md) instances. The property must be registered on the system and have isColumn and isInvertedIndex set to true. 
 
 You query over content by using Advanced Query Syntax (AQS).
 


### PR DESCRIPTION
Not all properties in the file system can be used with the ContentIndexer, adding details for how to check ahead of time if one will throw an exception when used.

There is more detail in the blog post linked below, but I'm not sure if we are able to link to blog posts from the docs or if there is another way to do it. 

https://blogs.msdn.microsoft.com/adamdwilson/2016/03/30/searching-private-app-data-in-windows-10/

Thanks 