### PR TITLE
Add warning not to use this API

### DIFF
--- a/windows.applicationmodel.extendedexecution.foreground/extendedexecutionforegroundsession.md
+++ b/windows.applicationmodel.extendedexecution.foreground/extendedexecutionforegroundsession.md
@@ -10,7 +10,7 @@ public class ExtendedExecutionForegroundSession : Windows.ApplicationModel.Exten
 # Windows.ApplicationModel.ExtendedExecution.Foreground.ExtendedExecutionForegroundSession
 
 ## -description
-Supports managing a request for extended foreground execution.
+Supports managing a request for extended execution. This API requires the use of restricted capabilities and cannot be used for Store applications.
 
 ## -remarks
 


### PR DESCRIPTION
This API is not approved for public developer use. Its use is only available with restricted capabilities and is not available for Store applications.