### PR TITLE
Clarification on the removal of EnableAsync()

### DIFF
--- a/windows.devices.pointofservice/linedisplay.md
+++ b/windows.devices.pointofservice/linedisplay.md
@@ -13,7 +13,7 @@ public class LineDisplay : IClosable
 Represents a line display device.
 
 ## -remarks
-This object is created when a [GetDefaultAsync](linedisplay_getdefaultasync.md) or [FromIdAsync](linedisplay_fromidasync.md) method completes.
+This object is created when a [GetDefaultAsync](linedisplay_getdefaultasync.md) or [FromIdAsync](linedisplay_fromidasync.md) method completes. Unlike other peripherals, the EnableAsync() method has been removed for line displays; Instead, the device is implicitly enabled whenever commands are sent that require the line display to be in an enabled state.
 
 ## -see-also
 


### PR DESCRIPTION
The "enable" step defined by the UPOS spec is done implicitly whenever a particular command requires that the device be enabled. For other peripherals, the caller must ensure that they call EnableAsync() before sending any commands that have an {enable} prerequisite.