### PR TITLE
AppDiagnosticInfo::RequestInfoAsync update

### DIFF
--- a/windows.system/appdiagnosticinfo_requestinfoasync_1918193949.md
+++ b/windows.system/appdiagnosticinfo_requestinfoasync_1918193949.md
@@ -18,7 +18,7 @@ Gets a collection of [AppDiagnosticInfo](appdiagnosticinfo.md) objects for all r
 A list of [AppDiagnosticInfo](appdiagnosticinfo.md) objects for all running apps that have a package family name. 
 
 ## -remarks
-
+This method must be called from a UI thread the first time it is used by an application.
 ## -see-also
 
 ## -examples


### PR DESCRIPTION
The first time AppDiagnosticInfo::RequestInfoAsync is called it must be done on a UI thread.