### PR TITLE
Update httpmaptiledatasource.md to mention breaking change

### DIFF
--- a/windows.ui.xaml.controls.maps/httpmaptiledatasource.md
+++ b/windows.ui.xaml.controls.maps/httpmaptiledatasource.md
@@ -1,3 +1,4 @@
+
 ---
 -api-id: T:Windows.UI.Xaml.Controls.Maps.HttpMapTileDataSource
 -api-type: winrt class
@@ -10,7 +11,7 @@ public class HttpMapTileDataSource : Windows.UI.Xaml.Controls.Maps.MapTileDataSo
 # Windows.UI.Xaml.Controls.Maps.HttpMapTileDataSource
 
 ## -description
-Provides a source of tiles for a [MapTileSource](maptilesource.md). The tiles are fetched by using the HTTP or HTTPS protocol.
+Provides a source of tiles for a [MapTileSource](maptilesource.md). The tiles are fetched by using the HTTP or HTTPS protocol. Note that, as of build 15063, local uris don't work anymore.
 
 ## -remarks
 


### PR DESCRIPTION
build 15063 introduced a limitation to this class: local uris don't work anymore. The documentation must mention this. By the way, thank the developers for this breaking change, warmly.