### PR TITLE
Adding a reference to ContentDialog to the Popup control's page remarks.

### DIFF
--- a/windows.ui.xaml.controls.primitives/popup.md
+++ b/windows.ui.xaml.controls.primitives/popup.md
@@ -1,3 +1,4 @@
+
 ---
 -api-id: T:Windows.UI.Xaml.Controls.Primitives.Popup
 -api-type: winrt class

--- a/windows.ui.xaml.controls.primitives/popup.md
+++ b/windows.ui.xaml.controls.primitives/popup.md
@@ -1,4 +1,4 @@
-
+ [
 ---
 -api-id: T:Windows.UI.Xaml.Controls.Primitives.Popup
 -api-type: winrt class
@@ -20,7 +20,7 @@ Displays content on top of existing content, within the bounds of the applicatio
 
 
 ## -remarks
-Do not use a [Popup](popup.md) if a [Flyout](../windows.ui.xaml.controls/flyout.md), [MenuFlyout](../windows.ui.xaml.controls/menuflyout.md), [ToolTip](../windows.ui.xaml.controls/tooltip.md) or [MessageDialog](../windows.ui.popups/messagedialog.md) is more appropriate.
+Do not use a [Popup](popup.md) if a [Flyout](../windows.ui.xaml.controls/flyout.md), [MenuFlyout](../windows.ui.xaml.controls/menuflyout.md), [ToolTip](../windows.ui.xaml.controls/tooltip.md) or [ContentDialog](../windows.ui.popups/contentdialog.md) ([MessageDialog](../windows.ui.popups/messagedialog.md) for a Windows 8 app) is more appropriate.
 
 
 <!--For more info, see Displaying popups. (Add this when the topic is created.)-->

--- a/windows.ui.xaml.controls.primitives/popup.md
+++ b/windows.ui.xaml.controls.primitives/popup.md
@@ -1,4 +1,3 @@
- [
 ---
 -api-id: T:Windows.UI.Xaml.Controls.Primitives.Popup
 -api-type: winrt class


### PR DESCRIPTION
The Popup page has a remark that notes that the Popup control should be avoided, preferring to use other, more precise controls. In this list is the MessageDialog, but the MessageDialog page itself notes that it is for Windows 8 apps being converted to the UWP, and instead new UWAs should use ContentDialog. I've added a direct reference to ContentDialog here, to reduce the number of navigations to reach the control a reader most likely wants to find.