### PR TITLE
Horizontally, not vertically

### DIFF
--- a/windows.ui.xaml.controls/gridview.md
+++ b/windows.ui.xaml.controls/gridview.md
@@ -23,7 +23,7 @@ Represents a control that displays data items in rows and columns.
 
 
 ## -remarks
-Use a [GridView](gridview.md) to display a collection of data in rows and columns that can scroll vertically. To display a collection stacked vertically, use a [ListView](listview.md).
+Use a [GridView](gridview.md) to display a collection of data in rows and columns that can scroll horizontally. To display a collection stacked vertically, use a [ListView](listview.md).
 
 <img alt="Grid view control" src="images/controls/GridViewBasic.png" />
 


### PR DESCRIPTION
If you go to [Controls by Function](https://docs.microsoft.com/en-us/windows/uwp/controls-and-patterns/controls-by-function) and scroll down to **GridView** you can see this line of text:

> A control that presents a collection of items in rows and columns that can scroll **horizontally**.

But on this page, it's written:

> Use a [GridView](gridview.md) to display a collection of data in rows and columns that can scroll **vertically**. To display a collection stacked **vertically**, use a [ListView](listview.md). 

So, which one is which?

