### PR TITLE
Calling out usage limitations

### DIFF
--- a/windows.ui.xaml.media.animation/repositionthemetransition.md
+++ b/windows.ui.xaml.media.animation/repositionthemetransition.md
@@ -19,6 +19,7 @@ Reacts to layout moves when no context is set and a trigger of *move* is passed.
 
 
 ## -remarks
+The RepositionThemeTransition is not designed to be used with Panels that perform UI virtualization such as the default Panel on a ListView or GridView control.
 
 ## -examples
 The following example applies a [RepositionThemeTransition](repositionthemetransition.md) to a button. When you click the button, its margin changes, which changes its position. This position change is animated.


### PR DESCRIPTION
RepositionThemeTransition is not supported in ListView, it was designed for use with non virtualizing panels like StackPanel.
ListView relies on AddDeleteThemeTransition for not only add (fade in) and delete (fade out) but also reposition of items when they move due to a collection change. It's expected they clash when both are used together.