### PR TITLE
Fixed typo in description for HttpStatusCode.None

### DIFF
--- a/windows.web.http/httpstatuscode.md
+++ b/windows.web.http/httpstatuscode.md
@@ -14,7 +14,7 @@ Contains the values of status codes defined for HTTP in the response to an HTTP 
 
 ## -enum-fields
 ### -field None:0
-The client request was successful.
+The client request wasn't successful.
 
 ### -field Continue:100
 The client should continue with its request.


### PR DESCRIPTION
I guess HttpStatusCode.None mean that request wasn't successful, is it?