### PR TITLE
Typo fix, and splitting CoreDispatcher.ProcessEvents by case.

### DIFF
--- a/windows.ui.core/coredispatcher_processevents_1611214514.md
+++ b/windows.ui.core/coredispatcher_processevents_1611214514.md
@@ -14,14 +14,17 @@ Starts the dispatcher processing the input event queue for this instance of [Cor
 
 ## -parameters
 ### -param options
-The options for processing window events.
+Determines how many events to process, and if this method should block.
 
 ## -remarks
-This method is called from the main app loop defined in the [IFrameworkView::Run](../windows.applicationmodel.core/iframeworkview.md) method you implemented on your view provider. Typically, you call it once on each iteration of the loop. If you are creating a Windows Store app using DirectX with C++, call this method with [CoreProcessEventsOption::ProcessAllIfPending](coreprocesseventsoption.md).
+### - Windows Store app using DirectX with C++
+Call this method to dispatch events from your view provider's main app loop defined in the [IFrameworkView::Run](../windows.applicationmodel.core/iframeworkview.md) method.  If your window is visible, call it with [CoreProcessEventsOption::ProcessAllIfPresent](coreprocesseventsoption.md) to dispatch current events and continue.  If your window is not visible, use [CoreProcessEventsOption::ProcessOneAndAllPending](coreprocesseventsoption.md) to block until the next event and prevent busy waiting.
 
+### - Other App Models
 If you are using another app model, such as XAML or JavaScript, you do not need to call this method. To avoid reentrancy scenarios in your Windows Store app using C++, C#, or Visual Basic with XAML, use the types and methods in the provided XAML namespaces, which call this method in the appropriate context.
-
-Also, this method fails if called recursively. When it fails, call [RoOriginateError](http://msdn.microsoft.com/library/ed647880-5a18-4f75-b7e5-3b9bf36229d3) to obtain the error and the message supplied to an attached debugger.
+ 
+## -warning
+This method fails if called recursively. When it fails, call [RoOriginateError](http://msdn.microsoft.com/library/ed647880-5a18-4f75-b7e5-3b9bf36229d3) to obtain the error and the message supplied to an attached debugger.
 
 ## -examples
 


### PR DESCRIPTION
- Clarifies the two situations involved in the use of this method.
- Fixes typo in previous recommended parameter for DirectX (value did not exist).
- Splits reentrancy concerns into a separate "warning" block for visibility.