### PR TITLE
Document BluetoothLEDevice.Close is used to close connections.

### DIFF
--- a/windows.devices.bluetooth/bluetoothledevice_close_811482585.md
+++ b/windows.devices.bluetooth/bluetoothledevice_close_811482585.md
@@ -11,7 +11,7 @@ public void Close()
 # Windows.Devices.Bluetooth.BluetoothLEDevice.Close
 
 ## -description
-Closes this Bluetooth LE device.
+Closes this Bluetooth LE device. This may close the connection to the device if this is the only app with a connection.
 
 ## -remarks
 


### PR DESCRIPTION
From Carter Appleton's response on https://stackoverflow.com/a/39521626/331858. I have not verified this personally.