### PR TITLE
Fix Typo in the Description of ScrollableHeight

### DIFF
--- a/windows.ui.xaml.controls/scrollviewer_scrollableheight.md
+++ b/windows.ui.xaml.controls/scrollviewer_scrollableheight.md
@@ -10,7 +10,7 @@ public double ScrollableHeight { get; }
 # Windows.UI.Xaml.Controls.ScrollViewer.ScrollableHeight
 
 ## -description
-Gets a value that represents the vertical size of the area that can be scrolled; the difference between the width of the extent and the width of the viewport.
+Gets a value that represents the vertical size of the area that can be scrolled; the difference between the height of the extent and the height of the viewport.
 
 ## -property-value
 The vertical size of the area that can be scrolled. This property has no default value.


### PR DESCRIPTION
For ScrollableHeight, the difference is taken between the height of the extent and the height of the viewport and not the width. This is a typo.