### PR TITLE
Change in MapControl description

### DIFF
--- a/windows.ui.xaml.controls.maps/mapcontrol.md
+++ b/windows.ui.xaml.controls.maps/mapcontrol.md
@@ -1,4 +1,4 @@
----
+a ---
 -api-id: T:Windows.UI.Xaml.Controls.Maps.MapControl
 -api-type: winrt class
 ---
@@ -10,7 +10,7 @@ public class MapControl : Windows.UI.Xaml.Controls.Control, Windows.UI.Xaml.Cont
 # Windows.UI.Xaml.Controls.Maps.MapControl
 
 ## -description
-Represents the map control, which displays a map.
+Represents a symbolic or photorealistic map of the Earth.
 
 ## -xaml-syntax
 ```xaml


### PR DESCRIPTION
The MapControl class doesn't represent a MapControl--it represents a map.  I was tempted to put "3D", but it has 2D views also.  I was tempted to put "interactive", but other controls are interactive without stating it.  So I settled on the fact that you can see it with imagery or just symbolically.