### PR TITLE
Added description of MaxValue of Canvas.ZIndex property (in remarks).

### DIFF
--- a/windows.ui.xaml.controls/canvas_zindexproperty.md
+++ b/windows.ui.xaml.controls/canvas_zindexproperty.md
@@ -17,6 +17,7 @@ The identifier for the [Canvas.ZIndex](canvas_zindex.md)  XAML attached propert
 
 ## -remarks
 This property is only an identifier for the property system, and isn't used in most app scenarios. In most cases you set the [Canvas.ZIndex](canvas_zindex.md)  XAML attached property in XAML and won't need this identifier.
+The maximum allowed value is `1000000` (one million).
 
 ## -examples
 

--- a/windows.ui.xaml.controls/canvas_zindexproperty.md
+++ b/windows.ui.xaml.controls/canvas_zindexproperty.md
@@ -16,7 +16,7 @@ Identifies the [Canvas.ZIndex](canvas_zindex.md)  XAML attached property.
 The identifier for the [Canvas.ZIndex](canvas_zindex.md)  XAML attached property.
 
 ## -remarks
-This property is only an identifier for the property system, and isn't used in most app scenarios. In most cases you set the [Canvas.ZIndex](canvas_zindex.md)  XAML attached property in XAML and won't need this identifier.
+This property is only an identifier for the property system, and isn't used in most app scenarios. In most cases you set the [Canvas.ZIndex](canvas_zindex.md)  XAML attached property in XAML and won't need this identifier.  
 The maximum allowed value is `1000000` (one million).
 
 ## -examples


### PR DESCRIPTION
It's important to point this out in the docs, because devs might want to go for `int.MaxValue`.
I tested the limit to be one million.