### PR TITLE
Update "user" parameter description for GetFolderForUserAsync

### DIFF
--- a/windows.storage/knownfolders_getfolderforuserasync_705109113.md
+++ b/windows.storage/knownfolders_getfolderforuserasync_705109113.md
@@ -14,8 +14,7 @@ Static method that returns a specified known folder for a [User](../windows.syst
 
 ## -parameters
 ### -param user
-The [User](../windows.system/user.md) for which the folder is returned.   
-Use nullptr for current user.
+The [User](../windows.system/user.md) for which the folder is returned. Use `null` for the current user.
 
 ### -param folderId
 The ID of the folder to be returned.

--- a/windows.storage/knownfolders_getfolderforuserasync_705109113.md
+++ b/windows.storage/knownfolders_getfolderforuserasync_705109113.md
@@ -14,7 +14,8 @@ Static method that returns a specified known folder for a [User](../windows.syst
 
 ## -parameters
 ### -param user
-The [User](../windows.system/user.md) for which the folder is returned.
+The [User](../windows.system/user.md) for which the folder is returned.   
+Use nullptr for current user.
 
 ### -param folderId
 The ID of the folder to be returned.


### PR DESCRIPTION
Users of this API can use this API without specific "user" parameter. The API will call against current user then.