### PR TITLE
Update appcapture_capturingchanged.md

### DIFF
--- a/windows.media.capture/appcapture_capturingchanged.md
+++ b/windows.media.capture/appcapture_capturingchanged.md
@@ -14,7 +14,7 @@ Raised when the capturing status changes.
 
 ## -remarks
 > [!WARNING]
-> You must unregister the handler for this event went your app is suspended.
+> You must unregister the handler for this event when your app is suspended.
 
 ## -examples
 


### PR DESCRIPTION
Fixed typo by replacing "went" with "when" in the context "went your app is suspended."