### PR TITLE
Update compass.md

### DIFF
--- a/windows.devices.sensors/compass.md
+++ b/windows.devices.sensors/compass.md
@@ -12,7 +12,7 @@ public class Compass : Windows.Devices.Sensors.ICompass, Windows.Devices.Sensors
 ## -description
 Represents a compass sensor.
 
-This sensor returns a heading with respect to True North and, possibly, Magnetic North. (The latter is dependent on the sensor capabilities.)
+This sensor returns a heading with respect to Magnetic North and, possibly, True North. (The latter is dependent on the system capabilities.)
 
 For an example implementation, see the [compass sample](https://github.com/Microsoft/Windows-universal-samples/tree/master/Samples/Compass).
 


### PR DESCRIPTION
Inverted "Magnetic North" and "True North". The magnetic north is given by the magnetometer on the device. The true north is computed based on the magnetic north and the declination angle (which depends on the location of the device on the earth. The closer to the north pole, the greater the declination angle is). The declination angle is typically calculated using GPS coordinates, which may not be available on all systems.