### PR TITLE
The origin c# method 'OnDisconnected' is wrong;

### DIFF
--- a/windows.ui.xaml.media/xamllight.md
+++ b/windows.ui.xaml.media/xamllight.md
@@ -109,8 +109,10 @@ public sealed class OrangeSpotLight : XamlLight
         // OnDisconnected is called when there are no more target UIElements on the screen. The CompositionLight should be disposed when no longer required.
         if (CompositionLight != null)
         {
-            CompositionLight.Dispose();
+            var temp = CompositionLight;
             CompositionLight = null;
+            temp.Dispose();
+            
         }
     }
 


### PR DESCRIPTION
if I use the origin sample code , it will throw a runtime exception about OnDisconnected method with message 'Access violation reading location 0x0000000000000000 '  at line 'CompositionLight=null;' , because before the line, it called CompositionLight.Dispose() , may there is a bug in the dispose method , it result the CompositionLight can' be accessed. So when we use 'CompositionLight=null' ,it will be result a runtime exception.
So I suggest change the sample code to 

    protected override void OnDisconnected(UIElement oldElement)
    {
        // OnDisconnected is called when there are no more target UIElements on the screen. The CompositionLight should be disposed when no longer required.
        
        if (CompositionLight != null)
        {
            var temp = CompositionLight;
            CompositionLight = null;
            temp.Dispose();    
        }
    }

It can avoid the runtime exception.