### PR TITLE
Clarify TabNavigation vs TabFocusNavigation

### DIFF
--- a/windows.ui.xaml/uielement_tabfocusnavigation.md
+++ b/windows.ui.xaml/uielement_tabfocusnavigation.md
@@ -26,7 +26,7 @@ A value of the enumeration. The default is **Local**.
 
 ## -remarks
 
-This property behaves the same as Control's [TabNavigation](../windows.ui.xaml.controls/control_tabnavigation.md) property. The reason that both properties exist is an accident of history. [TabNavigation](../windows.ui.xaml.controls/control_tabnavigation.md) is an older property. A problem with it was that it was only supported by [Controls]( ../windows.ui.xaml.controls/control.md) which forced developers to wrap non-[Controls]( ../windows.ui.xaml.controls/control.md) with a [Control]( ../windows.ui.xaml.controls/control.md) just so that they could leverage this property. [TabFocusNavigation](uielement_tabfocusnavigation.md) was introduced on [UIElement](uielement.md) to solve this problem.
+Use this property instead of the [Control.TabNavigation](../windows.ui.xaml.controls/control_tabnavigation.md) property for objects that do not use a [ControlTemplate](../windows.ui.xaml.controls/controltemplate.md) to define their appearance.
 
 ## -examples
 

--- a/windows.ui.xaml/uielement_tabfocusnavigation.md
+++ b/windows.ui.xaml/uielement_tabfocusnavigation.md
@@ -10,7 +10,7 @@ public KeyboardNavigationMode TabFocusNavigation { get;  set; }
 # Windows.UI.Xaml.UIElement.TabFocusNavigation
 
 ## -description
-Gets or sets a value that modifies how tabbing and [TabIndex](control_tabindex.md) work for this control.
+Gets or sets a value that modifies how tabbing and [TabIndex](../windows.ui.xaml.controls/control_tabindex.md) work for this control.
 
 ## -xaml-syntax
 ```xaml
@@ -25,6 +25,8 @@ Gets or sets a value that modifies how tabbing and [TabIndex](control_tabindex.m
 A value of the enumeration. The default is **Local**.
 
 ## -remarks
+
+This property behaves the same as Control's [TabNavigation](../windows.ui.xaml.controls/control_tabnavigation.md) property. The reason that both properties exist is an accident of history. [TabNavigation](../windows.ui.xaml.controls/control_tabnavigation.md) is an older property. A problem with it was that it was only supported by [Controls]( ../windows.ui.xaml.controls/control.md) which forced developers to wrap non-[Controls]( ../windows.ui.xaml.controls/control.md) with a [Control]( ../windows.ui.xaml.controls/control.md) just so that they could leverage this property. [TabFocusNavigation](uielement_tabfocusnavigation.md) was introduced on [UIElement](uielement.md) to solve this problem.
 
 ## -examples
 


### PR DESCRIPTION
There are two properties with similar names and identical descriptions:
  - Control's TabNavigation property
  - UIElement's TabFocusNavigation property

I updated the remarks section of TabFocusNavigation to explain the relationship between these two properties.

Additionally, I fixed a broken `TabIndex` link under the "description" section.