### PR TITLE
Update inkstroke_id.md

### DIFF
--- a/windows.ui.input.inking/inkstroke_id.md
+++ b/windows.ui.input.inking/inkstroke_id.md
@@ -18,8 +18,9 @@ An identifier is assigned to each ink stroke managed by the [InkPresenter](inkpr
 The unique identifier for the ink stroke.
 
 ## -remarks
-This unique identifier persists through serialization/deserialization of the ink stroke.
-A Clone() of an ink stroke will generate a new unique identifier.
+This unique identifier does not persist unchanged through serialization/deserialization of the ink stroke.
+After deserialization a new identifer will be assigned.
+A Clone() of an ink stroke will also generate a new unique identifier.
 
 ## -examples
 

--- a/windows.ui.input.inking/inkstroke_id.md
+++ b/windows.ui.input.inking/inkstroke_id.md
@@ -10,17 +10,17 @@ public uint Id { get; }
 # Windows.UI.Input.Inking.InkStroke.Id
 
 ## -description
-Gets the identifier for the ink stroke.
+Gets the the ink stroke identifier.
 
-An identifier is assigned to each ink stroke managed by the [InkPresenter](inkpresenter.md).
+A unique identifier is assigned to each ink stroke managed by the [InkPresenter](inkpresenter.md).
 
 ## -property-value
-The unique identifier for the ink stroke.
+The identifier for the ink stroke.
 
 ## -remarks
-This unique identifier does not persist unchanged through serialization/deserialization of the ink stroke.
-After deserialization a new identifer will be assigned.
-A Clone() of an ink stroke will also generate a new unique identifier.
+This identifier does not persist through serialization/deserialization of the ink stroke. After deserialization, a new identifer is assigned.
+
+Calling the **[Clone](https://docs.microsoft.com/uwp/api/Windows.UI.Input.Inking.InkStroke#Windows_UI_Input_Inking_InkStroke_Clone)** method also generates a new identifier for the cloned stroke.
 
 ## -examples
 


### PR DESCRIPTION
I counted on the documentation about the Id not changing through serialization/deserialization when building my app and found that to not be true. It also appears that it restarts the counter (at 1) upon load into a new InkStrokeContainer. I believe that the ID being unique only applies to a particular InkStrokeContainer instance. It would be nice to have some clarification about what is unique about the ID...