### PR TITLE
escape backslash in StorageFile.GetFileFromPathAsync

### DIFF
--- a/windows.storage/storagefile_getfilefrompathasync_1252266672.md
+++ b/windows.storage/storagefile_getfilefrompathasync_1252266672.md
@@ -16,7 +16,7 @@ Gets a [StorageFile](storagefile.md) object to represent the file at the specifi
 ### -param path
 The path of the file to get a [StorageFile](storagefile.md) to represent.
 
-If your path uses slashes, make sure you use backslashes (\). Forward slashes (/) are not accepted by this method.
+If your path uses slashes, make sure you use backslashes (\\). Forward slashes (/) are not accepted by this method.
 
 ## -returns
 When this method completes, it returns the file as a [StorageFile](storagefile.md).


### PR DESCRIPTION
I am not exactly sure how will the docs be rendered and if this fixes the missing backslash character [here](https://docs.microsoft.com/en-us/uwp/api/windows.storage.storagefile#Windows_Storage_StorageFile_GetFileFromPathAsync_System_String_). But i hope so