### PR TITLE
Clarify DisplayInformation docs for the app view relationship

### DIFF
--- a/windows.graphics.display/displayinformation.md
+++ b/windows.graphics.display/displayinformation.md
@@ -10,12 +10,14 @@ public class DisplayInformation : Windows.Graphics.Display.IDisplayInformation, 
 # Windows.Graphics.Display.DisplayInformation
 
 ## -description
-Monitors and controls physical display information. The class provides events to allow clients to monitor for changes in the display.
+Monitors and controls display-related information for an application view. The class provides events to allow clients to monitor for changes in the application view affecting which display(s) the view resides on, as well as changes in displays that can affect the application view.
 
 ## -remarks
+A [DisplayInformation](displayinformation.md) instance does not map to a specific display, but instead tracks display-related information for wherever the application view is placed. Calling [GetForCurrentView](displayinformation_getforcurrentview_1363600702.md) will always return the single instance for the current thread's [CoreApplicationView](../windows.applicationmodel.core/coreapplicationview.md). An instance of [DisplayInformation](displayinformation.md) can only be used from the thread on which it was created.
+
 To handle [DisplayInformation](displayinformation.md) events, use an event handler for the specific event. For example, for [DisplayInformation.DpiChanged](displayinformation_dpichanged.md), use "TypedEventHandler&lt;DisplayInformation, Object&gt; DpiChanged."
 
-Any property change event of [DisplayInformation](displayinformation.md) might trigger if your app is moved from one monitor to another monitor. [ColorProfileChanged](displayinformation_colorprofilechanged.md) is triggered when the display’s color profile changes. [DpiChanged](displayinformation_dpichanged.md) is triggered when either the [LogicalDpi](displayinformation_logicaldpi.md) or [ResolutionScale](displayinformation_resolutionscale.md) property changes because a user selected a different zoom level or changed the screen resolution. [OrientationChanged](displayinformation_orientationchanged.md) is triggered if a user changes the screen orientation.
+Any property change event of [DisplayInformation](displayinformation.md) might trigger if your app is moved from one monitor to another monitor. [ColorProfileChanged](displayinformation_colorprofilechanged.md) is triggered when the display’s color profile changes. [DpiChanged](displayinformation_dpichanged.md) is triggered when the [LogicalDpi](displayinformation_logicaldpi.md), [ResolutionScale](displayinformation_resolutionscale.md), and [RawPixelsPerViewPixel](displayinformation_rawpixelsperviewpixel.md) properties change because a user selected a different zoom level or changed the screen resolution. [OrientationChanged](displayinformation_orientationchanged.md) is triggered if a user changes the screen orientation.
 
 ## -examples
 

--- a/windows.graphics.display/displayinformation_getforcurrentview_1363600702.md
+++ b/windows.graphics.display/displayinformation_getforcurrentview_1363600702.md
@@ -10,13 +10,13 @@ public Windows.Graphics.Display.DisplayInformation GetForCurrentView()
 # Windows.Graphics.Display.DisplayInformation.GetForCurrentView
 
 ## -description
-Gets the current physical display information.
+Gets the  DisplayInformation instance associated with the current thread's [CoreApplicationView](../windows.applicationmodel.core/coreapplicationview.md). This DisplayInformation instance is tied to the view and cannot be used from other threads.
 
 ## -returns
-A [DisplayInformation](displayinformation.md) object that contains the current physical display information.
+A [DisplayInformation](displayinformation.md) object that provides display-related information for the current thread's view.
 
 ## -remarks
-This method is static.
+This method is static. This method can fail if the current thread is not the UI thread for an application view.
 
 ## -examples
 


### PR DESCRIPTION
Since we've received many questions about this, I've updated the DisplayInformation docs to clarify that GetForCurrentView returns a single instance per- application view. This instance is therefore tied to the view and does *not* represent information for a specific display (logical or physical), but rather provides display-related information for the view. The exact mapping from physical displays to logical displays to application view-related information is left up to the platform.