### PR TITLE
Remove link to bg task whitepaper

### DIFF
--- a/windows.applicationmodel.background/windows_applicationmodel_background.md
+++ b/windows.applicationmodel.background/windows_applicationmodel_background.md
@@ -8,13 +8,13 @@
 ## -description
 Enables an app to schedule background tasks to run app code even when the app is suspended.
 
-Background tasks are intended for small work items that do not require user interaction. Scenarios that are appropriate for background tasks include downloading mail, showing a toast notification for an incoming chat message, or reacting to a change in a system condition.
+Background tasks are intended for small work items that do not require user interaction or for handling toast actions. Scenarios that are appropriate for background tasks include downloading mail, showing a toast notification for an incoming chat message, or reacting to a change in a system condition.
 
-See [Supporting your app with background tasks ( using JavaScript and HTML)](http://msdn.microsoft.com/library/4c7bb148-eb1f-4640-865e-41f627a46e8e) or [Support your app with background tasks](http://msdn.microsoft.com/library/eff7cbfb-d309-4acb-a2a5-28e19d447e32) for guidance on implementing background tasks. For a general overview of background tasks in UWP app, see the [Introduction to Background Tasks](http://www.microsoft.com/download/en/details.aspx?id=27411) whitepaper. For example code that shows how to implement background tasks, see the [Background Task Sample](http://code.msdn.microsoft.com/windowsapps/Background-Task-Sample-9209ade9).
+See [Supporting your app with background tasks ( using JavaScript and HTML)](http://msdn.microsoft.com/library/4c7bb148-eb1f-4640-865e-41f627a46e8e) or [Support your app with background tasks](http://msdn.microsoft.com/library/eff7cbfb-d309-4acb-a2a5-28e19d447e32) for guidance on implementing background tasks. For example code that shows how to implement background tasks, see the [Background Task Sample](https://github.com/Microsoft/Windows-universal-samples/tree/master/Samples/BackgroundTask).
 
 ## -remarks
 
 ## -examples
 
 ## -see-also
-[Introduction to Background Tasks whitepaper](http://www.microsoft.com/download/en/details.aspx?id=27411), [Background Task Sample app](http://code.msdn.microsoft.com/windowsapps/Background-Task-Sample-9209ade9), [Background task sample (Windows 10)](http://go.microsoft.com/fwlink/p/?LinkId=618666), [Extended execution sample (Windows 10)](http://go.microsoft.com/fwlink/?LinkId=723509), [Custom USB device sample (Windows 10)](http://go.microsoft.com/fwlink/p/?LinkId=620530)
+[Background task sample (Windows 10)](http://go.microsoft.com/fwlink/p/?LinkId=618666), [Extended execution sample (Windows 10)](http://go.microsoft.com/fwlink/?LinkId=723509), [Custom USB device sample (Windows 10)](http://go.microsoft.com/fwlink/p/?LinkId=620530)


### PR DESCRIPTION
The  Background Task Whitepaper is from Windows 8. Removing Windows 8 links and replacing with Windows 10 information.