### PR TITLE
Update RequestRestartAsync

### DIFF
--- a/windows.applicationmodel.core/coreapplication_requestrestartasync_172604043.md
+++ b/windows.applicationmodel.core/coreapplication_requestrestartasync_172604043.md
@@ -23,7 +23,6 @@ The status of the restart request.
 * The app must be visible and foreground when it calls this API.
 * If the restart fails, but the user subsequently launches the app manually, the app will launch normally and no restart arguments will be passed.
 * If the app wasn't launched in the normal way, but was launched by a share contract, file picker, app-service, and so on, the app should not call this API because the user will not expect the resulting behavior.
-* The app is responsible for ensuring the validity of the **User** object. The activation will fail if there is policy in place which prevents that user from executing the app.
 * The app should not request an Extended Execution session after it has called this API because that will result in a poor user experience.
 * If the app has any in-process background tasks running when it calls this API, those tasks will be cancelled in the normal way. Out-of-process background tasks will not be affected.
 * When the app is restarted, [LaunchActivatedEventArgs.PreviousExecutionState](https://docs.microsoft.com/uwp/api/Windows.ApplicationModel.Activation.LaunchActivatedEventArgs) will have the value **Terminated** so that the app can distinguish between a resume and a restart.


### PR DESCRIPTION
The description about the user object is valid for the method RequestRestart"ForUser"Async, but not for this Method. This method does not use the user object as a parameter like as RequestRestartForUserAsync.
The description should be removed.