### PR TITLE
we found out Contact->ProviderProperties isn't persisted

### DIFF
--- a/windows.applicationmodel.contacts/contact_providerproperties.md
+++ b/windows.applicationmodel.contacts/contact_providerproperties.md
@@ -11,6 +11,7 @@ public Windows.Foundation.Collections.IPropertySet ProviderProperties { get; }
 
 ## -description
 Gets the property set object for the contact.
+Note: This property is not persisted if set by an application.
 
 ## -property-value
 The [IPropertySet](../windows.foundation.collections/ipropertyset.md) interface for the property set object for the contact.


### PR DESCRIPTION
We're likely not going to change this behavior as its only come up one time in 3 years, but thought it best to document it in case someone tries to do it.