### PR TITLE
Update use to 16299 SDK

### DIFF
--- a/windows.system.remotesystems/remotesystemsession.md
+++ b/windows.system.remotesystems/remotesystemsession.md
@@ -32,7 +32,7 @@ public async void JoinExistingSession() {
     if (joinResult.Status == RemoteSystemSessionJoinStatus.Success) {
         
         // if the join was successful, acquire a reference to the session
-        currentSession = joinResult.RemoteSystemSession;
+        currentSession = joinResult.Session;
         
         // optionally handle the disconnected event
         currentSession.Disconnected += async (sender, args) => {
@@ -74,9 +74,9 @@ public async void StartNewSharedExperience() {
     RemoteSystemSessionCreationResult createResult = await manager.CreateSessionAsync();
     
     // handle the creation result
-    if (createResult.Status == RemoteSystemSessionCreateStatus.Success) {
+    if (createResult.Status == RemoteSystemSessionCreationStatus.Success) {
         // creation was successful
-        RemoteSystemSession currentSession = createResult.RemoteSystemSession;
+        RemoteSystemSession currentSession = createResult.Session;
         
         // optionally subscribe to the disconnection event
         currentSession.Disconnected += async (sender, args) => {
@@ -86,7 +86,7 @@ public async void StartNewSharedExperience() {
     
         // Use session ...
     
-    } else if (createResult.Status == RemoteSystemSessionCreateStatus.SessionLimitsExceeded) {
+    } else if (createResult.Status == RemoteSystemSessionCreationStatus.SessionLimitsExceeded) {
         // creation failed. Optionally update UI to indicate that there are too many sessions in progress
     } else {
         // creation failed for an unknown reason. Optionally update UI


### PR DESCRIPTION
This sample had old names for some parameters. Updated to match 16299 SDK