### PR TITLE
Update radio_getradiosasync_548754145.md

### DIFF
--- a/windows.devices.radios/radio_getradiosasync_548754145.md
+++ b/windows.devices.radios/radio_getradiosasync_548754145.md
@@ -11,10 +11,10 @@ public Windows.Foundation.IAsyncOperation<Windows.Foundation.Collections.IVector
 # Windows.Devices.Radios.Radio.GetRadiosAsync
 
 ## -description
-A static, asynchronous method that retrieves a collection of [Windows.Devices.Radios.Radio](radio.md) objects representing radio devices existing on the system.
+A static, asynchronous method that retrieves a collection of [Windows.Devices.Radios.Radio](radio.md) objects representing radio devices which existed on the system at the time the program launched.  Additions or removals of radios are ignored by subsequent calls.
 
 ## -returns
-An asynchronous retrieval operation. When the operation is complete, contains a list of [Windows.Devices.Radios.Radio](radio.md) objects describing available radios.
+An asynchronous retrieval operation. When the operation is complete, contains a list of [Windows.Devices.Radios.Radio](radio.md) objects describing radios that existed at the time the program launched.
 
 ## -remarks
 


### PR DESCRIPTION
The Radio class functions have some operational defects.  GetRadiosAsync only works if your environment is static.  If radios are added or removed, the function does not reflect the changes when you call it again.  This is different than the behavior seen in Device Manager, which instantly reflects such a change.

In connection with that, the StateChanged function also fails to fire when you remove the radio from the system, as is common with USB Bluetooth dongles on laptops, or desktops with intermittent failures in a USB port, USB cable, or USB Bluetooth dongle on that cable.  Such failures are more common than would be desired in industrial settings, and software must diagnose the problem and assist in its correction.