### PR TITLE
Update radio_statechanged.md

### DIFF
--- a/windows.devices.radios/radio_statechanged.md
+++ b/windows.devices.radios/radio_statechanged.md
@@ -1,4 +1,4 @@
----
+  ---
 -api-id: E:Windows.Devices.Radios.Radio.StateChanged
 -api-type: winrt event
 -api-device-family-note: xbox
@@ -11,7 +11,7 @@ public event Windows.Foundation.TypedEventHandler StateChanged<Windows.Devices.R
 # Windows.Devices.Radios.Radio.StateChanged
 
 ## -description
-Event raised by a state change in the radio represented by this object.
+Event raised by a state change in the radio represented by this object.  When a USB Bluetooth radio is removed or otherwise goes offline, no state change is reported.
 
 ## -remarks
 

--- a/windows.devices.radios/radio_statechanged.md
+++ b/windows.devices.radios/radio_statechanged.md
@@ -1,4 +1,4 @@
-  ---
+---
 -api-id: E:Windows.Devices.Radios.Radio.StateChanged
 -api-type: winrt event
 -api-device-family-note: xbox


### PR DESCRIPTION
Unlike the case with Device Manager and third-party Bluetooth radio interfaces, the Microsoft UWP Radio class fails to notice the state change event when a USB Bluetooth radio is pulled or loses its power due to faulty USB port or faulty USB cable.  Since it fails to notice the event, it in turn fails to notify the application software which is monitoring the radio status. That application in turn fails to notify the user to take corrective action. This failure event is common in our industry, unfortunately.
