### PR TITLE
Update radio_getradiosasync_548754145.md

### DIFF
--- a/windows.devices.radios/radio_getradiosasync_548754145.md
+++ b/windows.devices.radios/radio_getradiosasync_548754145.md
@@ -12,12 +12,14 @@ public Windows.Foundation.IAsyncOperation<Windows.Foundation.Collections.IVector
 
 ## -description
 A static, asynchronous method that retrieves a collection of [Windows.Devices.Radios.Radio](radio.md) objects representing radio devices which existed on the system at the time the program launched.  Additions or removals of radios are ignored by subsequent calls.
-As of Windows10 1703 v15063, this method works ONLY when compiled for x64 target.  This is by design.
 
 ## -returns
 An asynchronous retrieval operation. When the operation is complete, contains a list of [Windows.Devices.Radios.Radio](radio.md) objects describing radios that existed at the time the program launched.
 
 ## -remarks
+When called from a UWP app, there is no architecture requirement. This method will work on the native architecture, as well as x86 architecture on x64 or ARM64 architectures.
+
+When this method is called from a desktop application (Win32), it will only retrieve radio instances when the application is in the native architecture, and x86 architectures running on x64 architectures will not see any radio instances.
 
 ## -examples
 

--- a/windows.devices.radios/radio_getradiosasync_548754145.md
+++ b/windows.devices.radios/radio_getradiosasync_548754145.md
@@ -12,6 +12,7 @@ public Windows.Foundation.IAsyncOperation<Windows.Foundation.Collections.IVector
 
 ## -description
 A static, asynchronous method that retrieves a collection of [Windows.Devices.Radios.Radio](radio.md) objects representing radio devices which existed on the system at the time the program launched.  Additions or removals of radios are ignored by subsequent calls.
+As of Windows10 1703 v15063, this method works ONLY when compiled for x64 target.  This is by design.
 
 ## -returns
 An asynchronous retrieval operation. When the operation is complete, contains a list of [Windows.Devices.Radios.Radio](radio.md) objects describing radios that existed at the time the program launched.


### PR DESCRIPTION
This problem (that is, design feature) was noticed in 2016 ( see https://github.com/Microsoft/cppwinrt/issues/47).

I verified that  Radios.GetAllAsync() works only when compiled for an x64 target.  It does not work for either x86 or AnyCpu.  With those two targets, a non-null unknown COM object is returned that will break the code and bypass a try-catch mechanism. The exception can be trapped with a try-finally.