### PR TITLE
Update bluetoothadapter_fromidasync_1322863552.md

### DIFF
--- a/windows.devices.bluetooth/bluetoothadapter_fromidasync_1322863552.md
+++ b/windows.devices.bluetooth/bluetoothadapter_fromidasync_1322863552.md
@@ -15,10 +15,10 @@ Gets a [BluetoothAdapter](bluetoothadapter.md) object identified by the given [D
 ## -parameters
 
 ### -param deviceId
-The DeviceId value that identifies the BluetoothAdapter instance.
+The DeviceId value that identifies the BluetoothAdapter instance. On a Windows10 workstation this is a composite string combining registry information that includes the MatchingDeviceId, the MAC address, and a GUID representing a device class . This is different than a DeviceInformation.Device.Id, except that both contain the MAC address of the Bluetooth radio device embedded within the identifier string.
 
 ## -returns
-After the asynchronous operation completes, returns the [BluetoothAdapter](bluetoothadapter.md) object identified by the given [DeviceId](bluetoothadapter_deviceid.md).
+After the asynchronous operation completes, returns the [BluetoothAdapter](bluetoothadapter.md) object identified by the given [DeviceId](bluetoothadapter_deviceid.md). 
 
 ## -remarks
 


### PR DESCRIPTION
The documentation about what a Device ID really is was will be inconsistent --- and implied that one Device ID obtained for a Bluetooth device could be used to obtain a BluetoothAdapter, which is not the case.  Given that the API set in this area is designed to fail when you compile for x86 or AnyCpu, failure at using one or the other Device ID was not a reliable indicator that the attempt was unreasonable.  I have documented what is contained in the Device ID to make it more understandable.