### PR TITLE
Update elementsoundplayer_volume.md

### DIFF
--- a/windows.ui.xaml/elementsoundplayer_volume.md
+++ b/windows.ui.xaml/elementsoundplayer_volume.md
@@ -10,10 +10,10 @@ public double Volume { get;  set; }
 # Windows.UI.Xaml.ElementSoundPlayer.Volume
 
 ## -description
-Gets or sets the volume of the sounds played by controls.
+Gets or sets the volume of the sounds played by the Play method.
 
 ## -property-value
-The volume of the sounds played by controls. The default is 1.0.
+The volume of the sounds played by the Play method. The default is 1.0.
 
 ## -remarks
 You can set the Volume property to reduce the volume relative to the system volume. 1.0 is the maximum and is equal to the system volume. 0.0 is the minimum and is the same as muted.


### PR DESCRIPTION
The text made the Volume property sound like it affected volume for all controls.  Actually, it affects the volume of the ElementSoundPlayer.Play() method.  Xaml controls do call that method, but other sound from controls, such as sound from MediaElement or WebView, are not affected.