### PR TITLE
The Deadline returns the actual time, not the duration

### DIFF
--- a/windows.applicationmodel/suspendingoperation_deadline.md
+++ b/windows.applicationmodel/suspendingoperation_deadline.md
@@ -10,10 +10,10 @@ public Windows.Foundation.DateTime Deadline { get; }
 # Windows.ApplicationModel.SuspendingOperation.Deadline
 
 ## -description
-Gets the time remaining before a delayed app suspending operation continues.
+Gets the time when the delayed app suspending operation continues.
 
 ## -property-value
-The time remaining.
+The time.
 
 ## -remarks
 


### PR DESCRIPTION
The Deadline property returns the time when the delayed app suspending continues. The current wording indicates that it returns the duration until continuation. To get the duration the user has to do Deadline - DateTimeOffset.Now