### PR TITLE
Update altitudereferencesystem.md

### DIFF
--- a/windows.devices.geolocation/altitudereferencesystem.md
+++ b/windows.devices.geolocation/altitudereferencesystem.md
@@ -33,7 +33,7 @@ The altitude reference system is based on the distance above the tallest surface
 The **Terrain**, **Geoid**, and **Surface** are implementation dependent and not mathematically precise.
 
 > [!NOTE]
-> The default altitude reference system that is used to provide location data depends on the GPS/GNSS radio hardware. Hardware typically found on older desktop PCs will continue using an **Ellipsoid** reference system. Everything else will default to using the **Geoid** reference system. To find out which one is being used by a [Geopoint](geopoint.md) object, see the [AltitudeReferenceSystem](geopoint_altitudereferencesystem.md) property.
+> The altitude reference system that is returned for location fixes from the geolocation API may depend on the GPS/GNSS radio hardware. Most modern hardware will provide values using the **Geoid** reference system. Most Map Control API's will return values in the **Elipsoid** system. To find out which one is being used by a [Geopoint](geopoint.md) object, see the [AltitudeReferenceSystem](geopoint_altitudereferencesystem.md) property. You should not copy a [BasicGeoposition] without also copying the associated [AltitudeReferenceSystem], otherwise the Altitude value will not be valid and could produce unexpected results.
 
 ## -examples
 

--- a/windows.devices.geolocation/altitudereferencesystem.md
+++ b/windows.devices.geolocation/altitudereferencesystem.md
@@ -33,7 +33,7 @@ The altitude reference system is based on the distance above the tallest surface
 The **Terrain**, **Geoid**, and **Surface** are implementation dependent and not mathematically precise.
 
 > [!NOTE]
-> The altitude reference system that is returned for location fixes from the geolocation API may depend on the GPS/GNSS radio hardware. Most modern hardware will provide values using the **Geoid** reference system. Most Map Control API's will return values in the **Elipsoid** system. To find out which one is being used by a [Geopoint](geopoint.md) object, see the [AltitudeReferenceSystem](geopoint_altitudereferencesystem.md) property. You should not copy a [BasicGeoposition] without also copying the associated [AltitudeReferenceSystem], otherwise the Altitude value will not be valid and could produce unexpected results.
+> The altitude reference system that is returned for location fixes from the geolocation API may depend on the GPS/GNSS radio hardware. Most modern hardware will provide values using the **Geoid** reference system, but Map Control APIs will return values in the **Elipsoid** system. To find out which one is being used by a [Geopoint](geopoint.md) object, see the [AltitudeReferenceSystem](geopoint_altitudereferencesystem.md) property. You should not copy a [BasicGeoposition] without also copying the associated [AltitudeReferenceSystem], otherwise the Altitude value will not be valid and could produce unexpected results.
 
 ## -examples
 

--- a/windows.devices.geolocation/altitudereferencesystem.md
+++ b/windows.devices.geolocation/altitudereferencesystem.md
@@ -33,7 +33,7 @@ The altitude reference system is based on the distance above the tallest surface
 The **Terrain**, **Geoid**, and **Surface** are implementation dependent and not mathematically precise.
 
 > [!NOTE]
-> The altitude reference system that is returned for location fixes from the geolocation API may depend on the GPS/GNSS radio hardware. Most modern hardware will provide values using the **Geoid** reference system, but Map Control APIs will return values in the **Elipsoid** system. To find out which one is being used by a [Geopoint](geopoint.md) object, see the [AltitudeReferenceSystem](geopoint_altitudereferencesystem.md) property. You should not copy a [BasicGeoposition] without also copying the associated [AltitudeReferenceSystem], otherwise the Altitude value will not be valid and could produce unexpected results.
+> The altitude reference system that is returned for location fixes from the geolocation API may depend on the GPS/GNSS radio hardware. Most modern hardware will provide values using the **Geoid** reference system, but Map Control APIs will return values in the **Elipsoid** system. To find out which one is being used by a [Geopoint](geopoint.md) object, see the [AltitudeReferenceSystem](geopoint_altitudereferencesystem.md) property. You should not copy a [BasicGeoposition](basicgeoposition.md) without also copying the associated [AltitudeReferenceSystem](geopoint_altitudereferencesystem.md), otherwise the Altitude value will not be valid and could produce unexpected results.
 
 ## -examples
 


### PR DESCRIPTION
The note was both inaccurate and misleading, implying that ellipsoid values were only used by older GPS hardware. Pretty much all GPS hardware will provide values using geoid, but all map control API's will use ellipsoid.