### PR TITLE
correcting binding type for image

### DIFF
--- a/windows.ai.machinelearning.preview/learningmodelbindingpreview.md
+++ b/windows.ai.machinelearning.preview/learningmodelbindingpreview.md
@@ -18,7 +18,7 @@ Represents the associations between model inputs and variable instances.
 
 ## -examples
  ```csharp
-public void PrepareBinding(LearningModelPreview model, SoftwareBitmap picture)
+public void PrepareBinding(LearningModelPreview model, VideoFrame picture)
 {
 	ImageVariableDescriptorPreview inputImageDescription;
 	List<ILearningModelVariableDescriptorPreview> inputFeatures = model.Description.InputFeatures.ToList();


### PR DESCRIPTION
Correcting the variable type we actually use for binding an image, from SoftwareBitmap to VideoFrame. The current example code would throw an exception otherwise.