### PR TITLE
Correcting the variable type for binding an image

### DIFF
--- a/windows.ai.machinelearning.preview/learningmodelbindingpreview_bind_765850420.md
+++ b/windows.ai.machinelearning.preview/learningmodelbindingpreview_bind_765850420.md
@@ -25,7 +25,7 @@ The value of the input/output feature.
 
 ## -examples
  ```csharp
-public void PrepareBinding(LearningModelPreview model, SoftwareBitmap picture)
+public void PrepareBinding(LearningModelPreview model, VideoFrame picture)
 {
 	ImageVariableDescriptorPreview inputImageDescription;
 	List<ILearningModelVariableDescriptorPreview> inputFeatures = model.Description.InputFeatures.ToList();


### PR DESCRIPTION
Correcting the variable type we actually use for binding an image, from SoftwareBitmap to VideoFrame. The current example code would throw an exception otherwise.