### PR TITLE
Correcting the variable type for binding an image

### DIFF
--- a/windows.ai.machinelearning.preview/learningmodelbindingpreview_clear_556466.md
+++ b/windows.ai.machinelearning.preview/learningmodelbindingpreview_clear_556466.md
@@ -18,7 +18,7 @@ Clears all bound variables.
 
 ## -examples
  ```csharp
-public void PrepareBinding(LearningModelPreview model, SoftwareBitmap picture)
+public void PrepareBinding(LearningModelPreview model, VideoFrame picture)
 {
 	ImageVariableDescriptorPreview inputImageDescription;
 	List<ILearningModelVariableDescriptorPreview> inputFeatures = model.Description.InputFeatures.ToList();


### PR DESCRIPTION
Correcting the variable type we actually use for binding an image, from SoftwareBitmap to VideoFrame. The current example code would throw an exception otherwise.