### PR TITLE
Update SwitchAsync for threading requirements

### DIFF
--- a/windows.ui.viewmanagement/applicationviewswitcher_switchasync_1398322393.md
+++ b/windows.ui.viewmanagement/applicationviewswitcher_switchasync_1398322393.md
@@ -20,6 +20,7 @@ The ID of the window under preparation for display.
 The asynchronous results of the operation. Use this to determine when the async call is complete.
 
 ## -remarks
+This method can only be called from the ASTA (core UI) thread of the calling, currently displayed window.
 
 ## -examples
 


### PR DESCRIPTION
This change notes the requirement that Windows.UI.ViewManagement.ApplicationViewSwitcher.SwitchAsync(System.Int32) must be called from the ASTA thread of the currently displayed window. Without explicitly following this requirement, applications may encounter unspecified error behavior.