### PR TITLE
Fix "See also" links for XAML headings documentation

### DIFF
--- a/windows.ui.xaml.automation.peers/automationheadinglevel.md
+++ b/windows.ui.xaml.automation.peers/automationheadinglevel.md
@@ -46,10 +46,6 @@ Heading level 9.
 ## -remarks
 
 ## -see-also
-[Landmarks and Headings](https://docs.microsoft.com/windows/uwp/design/accessibility/landmarks-and-headings)  
-[AutomationPeer.GetHeadingLevel](automationpeer_getheadinglevel_1176568834.md)  
-[AutomationPeer.GetHeadingLevelCore](automationpeer_getheadinglevelcore_1105552106.md)  
-[AutomationProperties.GetHeadingLevel](../windows.ui.xaml.automation/automationproperties_getheadinglevel_655629781.md)  
-[AutomationProperties.SetHeadingLevel](../windows.ui.xaml.automation/automationproperties_setheadinglevel_870496555.md)  
+[Landmarks and Headings](https://docs.microsoft.com/windows/uwp/design/accessibility/landmarks-and-headings), [AutomationPeer.GetHeadingLevel](automationpeer_getheadinglevel_1176568834.md), [AutomationPeer.GetHeadingLevelCore](automationpeer_getheadinglevelcore_1105552106.md), [AutomationProperties.GetHeadingLevel](../windows.ui.xaml.automation/automationproperties_getheadinglevel_655629781.md), [AutomationProperties.SetHeadingLevel](../windows.ui.xaml.automation/automationproperties_setheadinglevel_870496555.md)
 
 ## -examples

--- a/windows.ui.xaml.automation.peers/automationpeer_getheadinglevel_1176568834.md
+++ b/windows.ui.xaml.automation.peers/automationpeer_getheadinglevel_1176568834.md
@@ -23,8 +23,7 @@ Heading elements organize the user interface and make it easier to navigate. Som
 Examples of headings would be section titles within the Windows Settings app. For instance, under the **Ease of Access** -> **Mouse** page, **Pointer size**, **Pointer color**, and **Mouse keys** would be a heading of level 1.
 
 ## -see-also
-[AutomationHeadingLevel](automationheadinglevel.md)  
-[GetHeadingLevelCore](automationpeer_getheadinglevelcore_1105552106.md)
+[AutomationHeadingLevel](automationheadinglevel.md), [GetHeadingLevelCore](automationpeer_getheadinglevelcore_1105552106.md)
 
 ## -examples
 

--- a/windows.ui.xaml.automation/automationproperties_getheadinglevel_655629781.md
+++ b/windows.ui.xaml.automation/automationproperties_getheadinglevel_655629781.md
@@ -27,8 +27,7 @@ Heading elements organize the user interface and make it easier to navigate. Som
 Examples of headings would be section titles within the Windows Settings app. For instance, under the **Ease of Access** -> **Mouse** page, **Pointer size**, **Pointer color**, and **Mouse keys** would be a heading of level 1.
 
 ## -see-also
-[SetHeadingLevel](automationproperties_setheadinglevel_870496555.md)  
-[Landmarks and Headings](https://docs.microsoft.com/windows/uwp/design/accessibility/landmarks-and-headings)
+[SetHeadingLevel](automationproperties_setheadinglevel_870496555.md), [Landmarks and Headings](https://docs.microsoft.com/windows/uwp/design/accessibility/landmarks-and-headings)
 
 
 ## -examples

--- a/windows.ui.xaml.automation/automationproperties_headinglevelproperty.md
+++ b/windows.ui.xaml.automation/automationproperties_headinglevelproperty.md
@@ -21,9 +21,7 @@ Heading elements organize the user interface and make it easier to navigate. Som
 The heading level property value is returned by the [GetHeadingLevel](automationproperties_getheadinglevel_655629781.md) method.
 
 ## -see-also
-[GetHeadingLevel](automationproperties_getheadinglevel_655629781.md)  
-[SetHeadingLevel](automationproperties_setheadinglevel_870496555.md)  
-[Landmarks and Headings](https://docs.microsoft.com/windows/uwp/design/accessibility/landmarks-and-headings)
+[GetHeadingLevel](automationproperties_getheadinglevel_655629781.md), [SetHeadingLevel](automationproperties_setheadinglevel_870496555.md), [Landmarks and Headings](https://docs.microsoft.com/windows/uwp/design/accessibility/landmarks-and-headings)
 
 ## -examples
 ```xaml

--- a/windows.ui.xaml.automation/automationproperties_setheadinglevel_870496555.md
+++ b/windows.ui.xaml.automation/automationproperties_setheadinglevel_870496555.md
@@ -27,8 +27,7 @@ Heading elements organize the user interface and make it easier to navigate. Som
 Examples of headings would be section titles within the Windows Settings app. For instance, under the **Ease of Access** -> **Mouse** page, **Pointer size**, **Pointer color**, and **Mouse keys** would be a heading of level 1.
 
 ## -see-also
-[GetHeadingLevel](automationproperties_getheadinglevel_655629781.md)  
-[Landmarks and Headings](https://docs.microsoft.com/windows/uwp/design/accessibility/landmarks-and-headings)
+[GetHeadingLevel](automationproperties_getheadinglevel_655629781.md), [Landmarks and Headings](https://docs.microsoft.com/windows/uwp/design/accessibility/landmarks-and-headings)
 
 ## -examples
 


### PR DESCRIPTION
Comma-separation should fix formatting issues on these pages. 

See https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.automation.automationproperties.headinglevelproperty for an example of this bug