### PR TITLE
Update propertyvalue::createinspectabel to note that it's now optional

### DIFF
--- a/windows.foundation/propertyvalue_createinspectable_409346805.md
+++ b/windows.foundation/propertyvalue_createinspectable_409346805.md
@@ -10,11 +10,11 @@ public object CreateInspectable(System.Object value)
 # Windows.Foundation.PropertyValue.CreateInspectable
 
 ## -description
-Creates a property value from an inspectable object.
+Creates a property value from an inspectable object. Since an object is a reference type, it is also a valid property value and does not need to be boxed. This method returns the object provided without modification. An object can be set as a property value without first calling this method.
 
 ## -parameters
 ### -param value
-The object to store in the property value.
+The object to store in the property value. The value must be non-null.
 
 ## -returns
 The property value.

--- a/windows.foundation/propertyvalue_createinspectable_409346805.md
+++ b/windows.foundation/propertyvalue_createinspectable_409346805.md
@@ -10,7 +10,7 @@ public object CreateInspectable(System.Object value)
 # Windows.Foundation.PropertyValue.CreateInspectable
 
 ## -description
-Creates a property value from an inspectable object. Since an object is a reference type, it is also a valid property value and does not need to be boxed. This method returns the object provided without modification. An object can be set as a property value without first calling this method.
+Supplies the property value representation of an inspectable object. Since an object is a reference type, it is also a valid property value and does not need to be boxed. Instead, this method returns the object provided without modification. An object can be set as a property value without first calling this method.
 
 ## -parameters
 ### -param value


### PR DESCRIPTION
This method can basically be ignored. It's a no-op and leftovers from the early winrt days. Updating documentation to make it clearer how this API behaves.