### PR TITLE
Fix typos in method names

### DIFF
--- a/windows.media.apprecording/apprecordingstatus.md
+++ b/windows.media.apprecording/apprecordingstatus.md
@@ -10,15 +10,15 @@ public class AppRecordingStatus
 # Windows.Media.AppRecording.AppRecordingStatus
 
 ## -description
-Provides information about whether the current app is currently able to initiate an app recording by calling [StartRecordingToFileAsymc](apprecordingmanager_startrecordingtofileasync_706691331.md) or [RecordTimespanToFileAsymc](apprecordingmanager_recordtimespantofileasync_583577299.md), and if not, provides details about the reasons that app recording is unavailable.
+Provides information about whether the current app is currently able to initiate an app recording by calling [StartRecordingToFileAsync](apprecordingmanager_startrecordingtofileasync_706691331.md) or [RecordTimespanToFileAsync](apprecordingmanager_recordtimespantofileasync_583577299.md), and if not, provides details about the reasons that app recording is unavailable.
 
 ## -remarks
 Get an instance of this class by calling [AppRecordingManager.GetStatus](apprecordingmanager_getstatus_169641651.md).
 
 ## -see-also
 [AppRecordingManager.GetStatus](apprecordingmanager_getstatus_169641651.md)
-[StartRecordingToFileAsymc](apprecordingmanager_startrecordingtofileasync_706691331.md)
-[RecordTimespanToFileAsymc](apprecordingmanager_recordtimespantofileasync_583577299.md)
+[StartRecordingToFileAsync](apprecordingmanager_startrecordingtofileasync_706691331.md)
+[RecordTimespanToFileAsync](apprecordingmanager_recordtimespantofileasync_583577299.md)
 
 ## -examples
 


### PR DESCRIPTION
Were ending syMc instead on syNc.