### PR TITLE
Add detail on supported formats

### DIFF
--- a/windows.ui.xaml.controls.maps/mapicon_image.md
+++ b/windows.ui.xaml.controls.maps/mapicon_image.md
@@ -11,6 +11,11 @@ public Windows.Storage.Streams.IRandomAccessStreamReference Image { get;  set; }
 
 ## -description
 Gets or sets the image for the [MapIcon](mapicon.md). Provide an optional custom image to replace the default point of interest (POI) image.
+The following stream formats are supported:
+* PNG - a compressed PNG formatted stream
+* JPG - a compressed JPG formatted stream
+* BMP - an uncompressed BMP format stream
+* Raw RGB bytes. The size of the image is assumed to be square. This is only valid for a stream with an integral square root length. 
 
 ## -property-value
 The point of interest (POI) image for the [MapIcon](mapicon.md).


### PR DESCRIPTION
The contents of the stream are not described. The example shows a PNG stream, but it's useful to explicitly call out the supported formats for the stream.