### PR TITLE
fix the link rendering issue?

### DIFF
--- a/windows.devices.input.preview/gazedevicepreview_cantrackeyes.md
+++ b/windows.devices.input.preview/gazedevicepreview_cantrackeyes.md
@@ -23,8 +23,6 @@ At this time, no eye-tracking devices report head position, orientation, and mov
 
 ## -see-also
 
-### Conceptual
-
 [Gaze interactions and eye tracking in UWP apps](https://docs.microsoft.com/windows/uwp/design/input/gaze-interactions)
 
 ## -examples


### PR DESCRIPTION
The am not sure what the purpose of the coceptual header was, so I deleted it, because it messed up the rendering of the document especially the link to the other page. See https://docs.microsoft.com/en-us/uwp/api/windows.devices.input.preview.gazedevicepreview.cantrackeyes#Windows_Devices_Input_Preview_GazeDevicePreview_CanTrackEyes