### PR TITLE
Clarify the PausedSystemPolicy values (!phone)

### DIFF
--- a/windows.networking.backgroundtransfer/backgroundtransferstatus.md
+++ b/windows.networking.backgroundtransfer/backgroundtransferstatus.md
@@ -38,7 +38,7 @@ The transfer operation has been cancelled.
 An error was encountered during the transfer operation.
 
 ### -field PausedSystemPolicy:32
-Windows Phone only. The transfer is paused by the system due to resource constraints. Transfers will have this status if Battery Saver is activated, if the background task can't get enough memory, CPU, power resources to run, or if the network condition is 2G and the app is not in the foreground
+The transfer is paused by the system due to resource constraints. Examples of constraints include the system being on Battery Saver when the application is not in the foreground. In Windows Phone, transfers will have this status if Battery Saver is activated, if the background task can't get enough memory, CPU, power resources to run, or if the network condition is 2G and the app is not in the foreground
 
 ### -field PausedRecoverableWebErrorStatus:8
 One of the app-configured recoverable web error statuses ([RecoverableWebErrorStatuses](downloadoperation_recoverableweberrorstatuses.md)). 


### PR DESCRIPTION
The docs used to say that the PausedSystemPolicy value could only be returned on Windows Phone. Actually, the behavior was converged in TH1. The documentation should not be explicit about exactly when things get paused because (a) the NDX team wants to be able to change the exact times and (b) the system team wants to be able to turn background tasks on and off at will and definitely want to make more changes in the future.