### PR TITLE
Update default value for CalendarView.IsGroupLabelVisible

### DIFF
--- a/windows.ui.xaml.controls/calendarview_isgrouplabelvisible.md
+++ b/windows.ui.xaml.controls/calendarview_isgrouplabelvisible.md
@@ -19,7 +19,7 @@ Gets or sets a value that indicates whether the month name is shown with the fir
 
 
 ## -property-value
-**true** if the month name is shown with the first day of the month; otherwise, **false**. The default is **true**.
+**true** if the month name is shown with the first day of the month; otherwise, **false**. The default is **false**.
 
 ## -remarks
 


### PR DESCRIPTION
This property defaults to false (and not overridden by the default style)