### PR TITLE
SyndicationClient Fix #491

### DIFF
--- a/windows.web.syndication/syndicationclient.md
+++ b/windows.web.syndication/syndicationclient.md
@@ -33,10 +33,11 @@ function GetFeed(feedUri) {
 using Windows.Foundation;
 using Windows.Web.Syndication;
 
-async void GetFeed(feedUri){
-      Uri uri = new Uri(feedUri);
-      SyndicationClient client = new SyndicationClient();
-      client.BypassCacheOnRetrieve = true;
+async Task GetFeedAsync(string feedUri){
+      var uri = new Uri(feedUri);
+      var client = new SyndicationClient() {
+          BypassCacheOnRetrieve = true
+      };
       currentFeed = await client.RetrieveFeedAsync(uri);
 }
 


### PR DESCRIPTION
1- `feedUri` parameter set to `string`.
2- Rename method from `GetFeed` to `GetFeedAsync`.
3- Change return type of method from `void` to `Task`.
4- Simplify client declaration.