### PR TITLE
Updated mediatransportcontrols.md

### DIFF
--- a/windows.ui.xaml.controls/mediatransportcontrols.md
+++ b/windows.ui.xaml.controls/mediatransportcontrols.md
@@ -135,7 +135,7 @@ Here's how to configure transport control buttons in XAML. In this example, the 
 
 ```
 
-Notice that you can configure transport controls exactly the same way in MediaPlayerElement ( available after Anniversary Update 1607). In the example below we are setting IsCompactOverlayButtonVisible property ( only avaialbe after April 2018 Update 1803).
+Notice that you can configure transport controls exactly the same way in MediaPlayerElement ( available after Windows 10, version 1607). In the example below we are setting IsCompactOverlayButtonVisible property ( available after Windows 10, version 1803).
 
 ```xaml
 <MediaPlayerElement x:Name="mediaElement1" Source="ms-appx:///Assets/audio.wma"

--- a/windows.ui.xaml.controls/mediatransportcontrols.md
+++ b/windows.ui.xaml.controls/mediatransportcontrols.md
@@ -135,7 +135,7 @@ Here's how to configure transport control buttons in XAML. In this example, the 
 
 ```
 
-Notice that you can configure transport controls exactly the same way in MediaPlayerElement ( available after Windows 10, version 1607). In the example below we are setting IsCompactOverlayButtonVisible property ( available after Windows 10, version 1803).
+You can configure transport controls exactly the same way in MediaPlayerElement (available starting in Windows 10, version 1607). In the example below we are setting the IsCompactOverlayButtonVisible property (available starting in Windows 10, version 1803).
 
 ```xaml
 <MediaPlayerElement x:Name="mediaElement1" Source="ms-appx:///Assets/audio.wma"

--- a/windows.ui.xaml.controls/mediatransportcontrols.md
+++ b/windows.ui.xaml.controls/mediatransportcontrols.md
@@ -135,6 +135,18 @@ Here's how to configure transport control buttons in XAML. In this example, the 
 
 ```
 
+Notice that you can configure transport controls exactly the same way in MediaPlayerElement ( available after Anniversary Update 1607). In the example below we are setting IsCompactOverlayButtonVisible property ( only avaialbe after April 2018 Update 1803).
+
+```xaml
+<MediaPlayerElement x:Name="mediaElement1" Source="ms-appx:///Assets/audio.wma"
+          AreTransportControlsEnabled="True">
+    <MediaPlayerElement.TransportControls>
+        <MediaTransportControls IsCompactOverlayButtonVisible="True"/>
+    </MediaPlayerElement.TransportControls>
+</MediaPlayerElement>
+
+```
+
 Here's how to do the same thing in code. For simplicity, the code is placed in the `MainPage` constructor. `rootGrid` refers to the [Grid](grid.md) element that is created in MainPage.xaml. It has been named so that the [MediaElement](mediaelement.md) can be added to the XAML tree programmatically.
 
 ```csharp


### PR DESCRIPTION
Added an extra code snippet to show that MediaTransportControls work exactly the same way with MediaPlayerElement as well, it will be an easy copy and paste code snippet who wants to get started with MediaPlayerElement and in this example I am promoting the use of IsCompactOverlayButtonVisible="True", so that developers can be easily discover and be aware of this strong feature.