### PR TITLE
remove unnecessary colon from note-block

### DIFF
--- a/windows.applicationmodel.background/backgroundtaskdeferral.md
+++ b/windows.applicationmodel.background/backgroundtaskdeferral.md
@@ -14,7 +14,7 @@ Represents a background task deferral returned by the [IBackgroundTaskInstance.G
 
 ## -remarks
 > [!NOTE]
-> : This class is not agile, which means that you need to consider its threading model and marshaling behavior. For more info, see [Threading and Marshaling (C++/CX)](http://go.microsoft.com/fwlink/p/?linkid=258275) and [Using Windows Runtime objects in a multithreaded environment (.NET)](http://go.microsoft.com/fwlink/p/?linkid=258277).
+> This class is not agile, which means that you need to consider its threading model and marshaling behavior. For more info, see [Threading and Marshaling (C++/CX)](http://go.microsoft.com/fwlink/p/?linkid=258275) and [Using Windows Runtime objects in a multithreaded environment (.NET)](http://go.microsoft.com/fwlink/p/?linkid=258277).
 
 ## -examples
 The following example shows how to use a background task deferral to delay a task from closing prematurely while asynchronous code is still running. Ensure that you complete all background task deferrals. Most background tasks have a timeout after which the app will be suspended or terminated regardless of whether there are any pending deferrals. However, leaving outstanding background task deferrals interferes with the system's ability to manage process lifetimes in a timely way.


### PR DESCRIPTION
This removes an unnecessary colon from the [remarks](https://docs.microsoft.com/en-gb/uwp/api/Windows.ApplicationModel.Background.BackgroundTaskDeferral#remarks) in the BackgroundTaskDeferral documentation.