### PR TITLE
chore: fix definition list for Color

### DIFF
--- a/windows.ui/color.md
+++ b/windows.ui/color.md
@@ -46,15 +46,15 @@ Describes a color in terms of alpha, red, green, and blue channels.
 
 
 ## -xaml-values
-<dl><dt>predefinedColor</dt><dd>predefinedColorOne of the colors predefined by the Colors class. See members of Colors for a list. These are static properties. Specify just the color name, for example Transparent. Do not include the static class qualifier in the string: for example Colors.Transparent does not parse in XAML.</dd>
-<dt>rgb</dt><dd>rgbA three-character hexadecimal value. The first character specifies the color's R value, the second character specifies the G value, and the third character specifies the B value. For example, 00F.</dd>
-<dt>argb</dt><dd>argbA four-character hexadecimal value. The first character specifies the color's A value, the second character specifies its R value, the third character specifies the G value, and the fourth character specifies its B value. For example, F00F.</dd>
-<dt>rrggbb</dt><dd>rrggbbA six-character hexadecimal value. The first two characters specify the color's R value, the next two specify its G value, and the final two specify its B value. For example, 0000FF.</dd>
-<dt>aarrggbb</dt><dd>aarrggbbAn eight-character hexadecimal value. The first two characters specify the color's A value, the next two specify its R value, the next two specify its G value, and the final two specify its B value. For example, FF0000FF.</dd>
-<dt>scA</dt><dd>scAThe color's ScA value as a value between 0 and 1.</dd>
-<dt>scR</dt><dd>scRThe color's ScR value as a value between 0 and 1.</dd>
-<dt>scG</dt><dd>scGThe color's ScG value as a value between 0 and 1.</dd>
-<dt>scB</dt><dd>scBThe color's ScB value as a value between 0 and 1.</dd>
+<dl><dt>predefinedColor</dt><dd>One of the colors predefined by the Colors class. See members of Colors for a list. These are static properties. Specify just the color name, for example Transparent. Do not include the static class qualifier in the string: for example Colors.Transparent does not parse in XAML.</dd>
+<dt>rgb</dt><dd>A three-character hexadecimal value. The first character specifies the color's R value, the second character specifies the G value, and the third character specifies the B value. For example, 00F.</dd>
+<dt>argb</dt><dd>A four-character hexadecimal value. The first character specifies the color's A value, the second character specifies its R value, the third character specifies the G value, and the fourth character specifies its B value. For example, F00F.</dd>
+<dt>rrggbb</dt><dd>A six-character hexadecimal value. The first two characters specify the color's R value, the next two specify its G value, and the final two specify its B value. For example, 0000FF.</dd>
+<dt>aarrggbb</dt><dd>An eight-character hexadecimal value. The first two characters specify the color's A value, the next two specify its R value, the next two specify its G value, and the final two specify its B value. For example, FF0000FF.</dd>
+<dt>scA</dt><dd>The color's ScA value as a value between 0 and 1.</dd>
+<dt>scR</dt><dd>The color's ScR value as a value between 0 and 1.</dd>
+<dt>scG</dt><dd>The color's ScG value as a value between 0 and 1.</dd>
+<dt>scB</dt><dd>The color's ScB value as a value between 0 and 1.</dd>
 </dl>
 
 ## -struct-fields


### PR DESCRIPTION
The definition list term was stuck to the front of the definition list value