### PR TITLE
Removed migration info from Windows 8 to 8.1.

### DIFF
--- a/windows.ui.xaml.media.imaging/bitmapimage_urisource.md
+++ b/windows.ui.xaml.media.imaging/bitmapimage_urisource.md
@@ -26,14 +26,6 @@ The [BaseUri](../windows.ui.xaml/frameworkelement_baseuri.md) property might be 
 
 In low memory situations (most likely on lower-memory phones), it is possible for an exception to be raised with the message "The image is unrecognized" and an HRESULT of 0x88982F60. While this exception ordinarily indicates bad data, if your app is close to its memory limit then the cause of the exception is likely to be low memory. In that case, we recommend that you free memory and try again.
 
-
-<!--The following remark is relevant for Windows 8 > 8.1 migration. See WBB 464216-->
-### Windows 8 behavior
-
-Windows 8 had URI validation logic associated with this property's setter. Starting with Windows 8.1 that validation on the property setter is removed. That doesn't mean you get no validation, it means that you get the same final validation you should be using anyway: handling for **ImageOpened** or **ImageFailed** events on the [Image](../windows.ui.xaml.controls/image.md) where the source is applied.
-
-Apps that were compiled for Windows 8 but running on Windows 8.1 use the new Windows 8.1 behavior.
-
 ## -examples
 
 ## -see-also


### PR DESCRIPTION
The [BitmapImage] class described here is for the UWP platform which is exclusive to Windows 10. However, there is an entire paragraph dedicated to porting an app from Windows 8 to Windows 8.1.

More than 3 years into Windows 10's life, I guess it is reasonable to assume that no one is porting apps from Windows 8 to Windows 8.1 or to Windows 10 any longer. Hence, any such reference to Windows 8 (8.1) should be removed from this UWP documentation as it is merely a big wall of unnecessary information.