### PR TITLE
Remove useless Windows (Phone) 8/8.1 information

### DIFF
--- a/windows.storage.pickers/fileopenpicker.md
+++ b/windows.storage.pickers/fileopenpicker.md
@@ -15,16 +15,11 @@ Represents a UI element that lets the user choose and open files.
 
 ## -remarks
 
-To get started accessing files and folders file picker, see [Quickstart: Accessing files with ](http://msdn.microsoft.com/library/df082239-381c-462f-9f97-d2b390a2052e).
-
-To learn about using file pickers in Windows Phone 8.x app, see [How to continue your Windows Phone app after calling a file picker](http://msdn.microsoft.com/library/465bbb7a-9ed1-4b57-b60f-e5c6e7cd1470).
-
-> [!IMPORTANT]
-> In Windows 8 if you attempt to display the file picker while your app is snapped, the file picker will not be shown and an exception will be thrown. You can avoid this by making sure your app is not snapped, or by unsnapping it before you call the file picker. The following code examples and the [File picker sample](http://go.microsoft.com/fwlink/p/?linkid=234890) show you how. Note that Windows 8.1 does not define a specific snapped window size. Instead, users can resize apps to any width, down to the minimum. Therefore, if your app will deploy only on Windows 8.1, you can ignore the **EnsureUnsnapped** function and calls to it in this topic's example code.
+To get started accessing files and folders file picker, see [Quickstart: Accessing files with File Pickers](https://docs.microsoft.com/en-us/windows/uwp/files/quickstart-using-file-and-folder-pickers).
 
 ## -examples
 
-The [File picker sample](http://go.microsoft.com/fwlink/p/?linkid=234890) demonstrates how to check whether the app is snapped, how to set file picker properties, and how to show a file picker so that the user can pick one file.
+The [File picker sample](http://go.microsoft.com/fwlink/p/?LinkId=619994) demonstrates how to check whether the app is snapped, how to set file picker properties, and how to show a file picker so that the user can pick one file.
 
 [!code-csharp[all_openpicker_checksnapped_showsingle](../windows.storage.pickers/code/FilePicker/CS/Scenario1.xaml.cs#Snippetall_openpicker_checksnapped_showsingle)]
 
@@ -41,5 +36,4 @@ The [File picker sample](http://go.microsoft.com/fwlink/p/?linkid=234890) demons
 
 ## -see-also
 
-[File picker sample](http://go.microsoft.com/fwlink/p/?linkid=234890), [Quickstart: Accessing files with ](http://msdn.microsoft.com/library/df082239-381c-462f-9f97-d2b390a2052e), [How to continue your Windows Phone app after calling a file picker](http://msdn.microsoft.com/library/465bbb7a-9ed1-4b57-b60f-e5c6e7cd1470), [Blobs sample (Windows 10)](http://go.microsoft.com/fwlink/p/?LinkId=620573), [File picker sample (Windows 10)](http://go.microsoft.com/fwlink/p/?LinkId=619994)
-ample (Windows 10)](http://go.microsoft.com/fwlink/p/?LinkId=619994)
+[File picker sample](http://go.microsoft.com/fwlink/p/?LinkId=619994), [Quickstart: Accessing files with File Pickers ](https://docs.microsoft.com/en-us/windows/uwp/files/quickstart-using-file-and-folder-pickers), [Blobs sample](http://go.microsoft.com/fwlink/p/?LinkId=620573)

--- a/windows.storage.pickers/fileopenpicker.md
+++ b/windows.storage.pickers/fileopenpicker.md
@@ -15,7 +15,7 @@ Represents a UI element that lets the user choose and open files.
 
 ## -remarks
 
-To get started accessing files and folders file picker, see [Quickstart: Accessing files with File Pickers](https://docs.microsoft.com/en-us/windows/uwp/files/quickstart-using-file-and-folder-pickers).
+To get started accessing files and folders file picker, see [Quickstart: Accessing files with File Pickers](https://docs.microsoft.com/windows/uwp/files/quickstart-using-file-and-folder-pickers).
 
 ## -examples
 
@@ -36,4 +36,4 @@ The [File picker sample](http://go.microsoft.com/fwlink/p/?LinkId=619994) demons
 
 ## -see-also
 
-[File picker sample](http://go.microsoft.com/fwlink/p/?LinkId=619994), [Quickstart: Accessing files with File Pickers ](https://docs.microsoft.com/en-us/windows/uwp/files/quickstart-using-file-and-folder-pickers), [Blobs sample](http://go.microsoft.com/fwlink/p/?LinkId=620573)
+[File picker sample](http://go.microsoft.com/fwlink/p/?LinkId=619994), [Quickstart: Accessing files with File Pickers ](https://docs.microsoft.com/windows/uwp/files/quickstart-using-file-and-folder-pickers), [Blobs sample](http://go.microsoft.com/fwlink/p/?LinkId=620573)


### PR DESCRIPTION
The [FileOpenPicker] class described here is a component of the UWP platform which is exclusive to Windows 10. Hence, any information about how to use it on other platforms (such as Windows 8/8.1 or Windows Phone 8) is irrelevant and should be cut from this documentation. 

This commit removes any references to non-Windows 10 API usages and also updates several links in the [See also] section to point to the the correct Windows 10 information.

*** End of basic commit information ***

General note: I posted an issue about this exact documentation issue on github MONTHS ago (back in May 2018) yet never got any reply from the MS docs team. (See: https://github.com/MicrosoftDocs/winrt-api/issues/373) So after months of waiting, here is my pull-request doing the job I reoprted to you guys all the while back. Hopefully, you can at least comment on it (if it will be approved, and if not, why).

While I love the new feedback system, it is pointless if you keep ignoring suggestions/requests made by your audience. Just browsing through the issues list for this repository (winrt-api) shows tons of user-requested changes without even A SINGLE COMMENT from the Microsoft team. Denying a request is one thing, but for you guys to not even comment on posted issues and why they won't be worked on is hugely disappointing!

Example issue which has been posted multiple times without any update: https://github.com/MicrosoftDocs/winrt-api/issues/387

If you keep ignoring your audience's ideas/requests, why even bother setting up such a nice feedback system?

Comments appreciated.