### PR TITLE
StorageFile.GetThumbnailAsync: Updated and Removed outdated/duplicate…

### DIFF
--- a/windows.storage/storagefile_getthumbnailasync_1575071988.md
+++ b/windows.storage/storagefile_getthumbnailasync_1575071988.md
@@ -16,15 +16,10 @@ Retrieves an adjusted thumbnail image for the file, determined by the purpose of
 ### -param mode
 The enum value that describes the purpose of the thumbnail and determines how the thumbnail image is adjusted.
 
-For guidance about choosing the best thumbnail mode, see [Guidelines and checklist for thumbnails](http://msdn.microsoft.com/library/46868748-8847-49ed-a07f-324e77b27da4).
+For guidance about choosing the best thumbnail mode, see [Guidelines and checklist for thumbnails](https://docs.microsoft.com/windows/uwp/files/thumbnails).
 
 ## -returns
 When this method completes successfully, it returns a [StorageItemThumbnail](../windows.storage.fileproperties/storageitemthumbnail.md) that represents the thumbnail image or **null** if there is no thumbnail image associated with the file.
-
-## -remarks
-For guidance about choosing the best thumbnail mode, see [Guidelines and checklist for thumbnails](http://msdn.microsoft.com/library/46868748-8847-49ed-a07f-324e77b27da4).
-
-> In Windows Phone 8.x app, the [StorageFile.GetThumbnailAsync](storagefile_getthumbnailasync_1511435522.md) method returns the default icon for a music file instead of the expected icon. This happens when you call the [StorageFile.GetThumbnailAsync](storagefile_getthumbnailasync_1511435522.md) method with a [ThumbnailMode](../windows.storage.fileproperties/thumbnailmode.md) value of **MusicView**.
 
 ## -examples
 


### PR DESCRIPTION
…d information

This PR removes duplicated information (thumbnail mode guidance), updates the link to the correct guidance (previously, the overview [Files, folders, and libraries] was opened) and removes information specific to Windows Phone 8.x behavior.

About Windows Phone 8.1 information removal:
In other PRs by me, a discussion is on-going how to treat behavior information about older Windows systems (such as Windows 8/8.1). It was pointed out that Windows 8.1 is still on extended support until January, 2023, hence why it might be, as of now, too soon to remove Windows 8.1 specific info.
In this case, however, Windows **Phone** 8.x is mentioned, which stopped getting any support nearly 18 months ago (July 11, 2017). I think we can safely assume that there no longer is a target audience for Windows Phone 8.x specific information and that any developer still working on a Windows Mobile app has long since updated his/her apps to Windows 10 mobile (which is also extremely close to its official end-of-life). 
Hence, I propose, with this PR, to cut the outdated Windows Phone 8.x information from the UWP documentation.