### PR TITLE
Update TextBox/RichEditBox.InputScope

### DIFF
--- a/windows.ui.xaml.controls/richeditbox_inputscope.md
+++ b/windows.ui.xaml.controls/richeditbox_inputscope.md
@@ -41,7 +41,8 @@ The input scope provides a hint at the type of text input expected by the contro
 
 The control might also interpret the data being entered differently (typically for East Asian related input scopes). The input scope does not perform any validation, and does not prevent the user from providing any input through a hardware keyboard or other input device.
 
-Note that while this property can hold a collection of InputeNameScope values, only the first is used, and the rest are ignored.
+> [!NOTE]
+> While this property can hold a collection of InputeNameScope values, only the first is used, and the rest are ignored.
 
 ## -examples
 Here's how to set the [InputScope](../windows.ui.xaml.input/inputscope.md) in XAML and in code.

--- a/windows.ui.xaml.controls/richeditbox_inputscope.md
+++ b/windows.ui.xaml.controls/richeditbox_inputscope.md
@@ -41,6 +41,8 @@ The input scope provides a hint at the type of text input expected by the contro
 
 The control might also interpret the data being entered differently (typically for East Asian related input scopes). The input scope does not perform any validation, and does not prevent the user from providing any input through a hardware keyboard or other input device.
 
+Note that while this property can hold a collection of InputeNameScope values, only the first is used, and the rest are ignored.
+
 ## -examples
 Here's how to set the [InputScope](../windows.ui.xaml.input/inputscope.md) in XAML and in code.
 

--- a/windows.ui.xaml.controls/textbox_inputscope.md
+++ b/windows.ui.xaml.controls/textbox_inputscope.md
@@ -43,6 +43,8 @@ The control might also interpret the data being entered differently (typically f
 
 Other properties that affect the touch keyboard are [IsSpellCheckEnabled](textbox_isspellcheckenabledproperty.md), [IsTextPredictionEnabled](textbox_istextpredictionenabledproperty.md), and [PreventKeyboardDisplayOnProgrammaticFocus](textbox_preventkeyboarddisplayonprogrammaticfocus.md). For more info and examples, see [Use input scope to change the touch keyboard](http://msdn.microsoft.com/library/6e5f55d7-24d6-47cc-b457-b6231ede2a71).
 
+Note that while this property can hold a collection of InputeNameScope values, only the first is used, and the rest are ignored.
+
 ## -examples
 Here's how to set the [InputScope](../windows.ui.xaml.input/inputscope.md) in XAML and in code.
 

--- a/windows.ui.xaml.controls/textbox_inputscope.md
+++ b/windows.ui.xaml.controls/textbox_inputscope.md
@@ -43,7 +43,8 @@ The control might also interpret the data being entered differently (typically f
 
 Other properties that affect the touch keyboard are [IsSpellCheckEnabled](textbox_isspellcheckenabledproperty.md), [IsTextPredictionEnabled](textbox_istextpredictionenabledproperty.md), and [PreventKeyboardDisplayOnProgrammaticFocus](textbox_preventkeyboarddisplayonprogrammaticfocus.md). For more info and examples, see [Use input scope to change the touch keyboard](http://msdn.microsoft.com/library/6e5f55d7-24d6-47cc-b457-b6231ede2a71).
 
-Note that while this property can hold a collection of InputeNameScope values, only the first is used, and the rest are ignored.
+> [!NOTE]
+> While this property can hold a collection of InputeNameScope values, only the first is used, and the rest are ignored.
 
 ## -examples
 Here's how to set the [InputScope](../windows.ui.xaml.input/inputscope.md) in XAML and in code.


### PR DESCRIPTION
Add:

Note that while this property can hold a collection of InputeNameScope values, only the first is used, and the rest are ignored.
