### PR TITLE
Updates the remarks for RenderTargetBitmap class

### DIFF
--- a/windows.ui.xaml.media.imaging/rendertargetbitmap.md
+++ b/windows.ui.xaml.media.imaging/rendertargetbitmap.md
@@ -42,7 +42,7 @@ There are a few scenarios for XAML-composed visual content that you can't captur
 + Content that's not directly connected to the XAML visual tree and the content of the main window won't be captured. This includes [Popup](../windows.ui.xaml.controls.primitives/popup.md) content, which is considered to be like a sub-window.
 + For Windows Phone 8.x app: the contents of a [WebView](../windows.ui.xaml.controls/webview.md) control can't be rendered into a [RenderTargetBitmap](rendertargetbitmap.md).
 + Content that can't be captured will appear as blank in the captured image, but other content in the same visual tree can still be captured and will render (the presence of content that can't be captured won't invalidate the entire capture of that XAML composition).
-+ Content that's in the XAML visual tree but offscreen can be captured, so long as it's not [Visibility](../windows.ui.xaml/uielement_visibility.md) =**Collapsed** or in the other restricted cases.
++ Content that's in the XAML visual tree but offscreen can be captured, so long as it's not [Visibility](../windows.ui.xaml/uielement_visibility.md) = **Collapsed** or in the other restricted cases.
 
 
 ## -examples

--- a/windows.ui.xaml.media.imaging/rendertargetbitmap_renderasync_1804035726.md
+++ b/windows.ui.xaml.media.imaging/rendertargetbitmap_renderasync_1804035726.md
@@ -33,9 +33,11 @@ You can pass **null** for the *element* parameter, and that renders the root vis
 There are a few scenarios for XAML-composed visual content that you can't capture to a [RenderTargetBitmap](rendertargetbitmap.md):
 + Video content in a [MediaElement](../windows.ui.xaml.controls/mediaelement.md) or [CaptureElement](../windows.ui.xaml.controls/captureelement.md) can't be captured using [RenderTargetBitmap](rendertargetbitmap.md). That includes capturing frames from within video content.
 + Custom Microsoft DirectX content (your own swap chain) inside a [SwapChainBackgroundPanel](../windows.ui.xaml.controls/swapchainbackgroundpanel.md) or [SwapChainPanel](../windows.ui.xaml.controls/swapchainpanel.md) can't be captured using [RenderTargetBitmap](rendertargetbitmap.md).
-+ Content that's in the XAML visual tree but offscreen won't be captured. Content that's in the tree but with its [Visibility](../windows.ui.xaml/uielement_visibility.md) set to **Collapsed** won't be captured.
++ Content that's in the tree but with its [Visibility](../windows.ui.xaml/uielement_visibility.md) set to **Collapsed** won't be captured.
 + Content that's not directly connected to the XAML visual tree and the content of the main window won't be captured. This includes [Popup](../windows.ui.xaml.controls.primitives/popup.md) content, which is considered to be like a sub-window.
++ For Windows Phone 8.x app: the contents of a [WebView](../windows.ui.xaml.controls/webview.md) control can't be rendered into a [RenderTargetBitmap](rendertargetbitmap.md).
 + Content that can't be captured will appear as blank in the captured image, but other content in the same visual tree can still be captured and will render (the presence of content that can't be captured won't invalidate the entire capture of that XAML composition).
++ Content that's in the XAML visual tree but offscreen can be captured, so long as it's not [Visibility](../windows.ui.xaml/uielement_visibility.md) = **Collapsed** or in the other restricted cases.
 
 
 ## -examples

--- a/windows.ui.xaml.media.imaging/rendertargetbitmap_renderasync_806843678.md
+++ b/windows.ui.xaml.media.imaging/rendertargetbitmap_renderasync_806843678.md
@@ -51,9 +51,11 @@ The maximum rendered size of a XAML visual tree is restricted by the maximum dim
 There are a few scenarios for XAML-composed visual content that you can't capture to a [RenderTargetBitmap](rendertargetbitmap.md):
 + Video content in a [MediaElement](../windows.ui.xaml.controls/mediaelement.md) or [CaptureElement](../windows.ui.xaml.controls/captureelement.md) can't be captured using [RenderTargetBitmap](rendertargetbitmap.md). That includes capturing frames from within video content.
 + Custom Microsoft DirectX content (your own swap chain) inside a [SwapChainBackgroundPanel](../windows.ui.xaml.controls/swapchainbackgroundpanel.md) or [SwapChainPanel](../windows.ui.xaml.controls/swapchainpanel.md) can't be captured using [RenderTargetBitmap](rendertargetbitmap.md).
-+ Content that's in the XAML visual tree but offscreen won't be captured. Content that's in the tree but with its [Visibility](../windows.ui.xaml/uielement_visibility.md) set to **Collapsed** won't be captured.
++ Content that's in the tree but with its [Visibility](../windows.ui.xaml/uielement_visibility.md) set to **Collapsed** won't be captured.
 + Content that's not directly connected to the XAML visual tree and the content of the main window won't be captured. This includes [Popup](../windows.ui.xaml.controls.primitives/popup.md) content, which is considered to be like a sub-window.
++ For Windows Phone 8.x app: the contents of a [WebView](../windows.ui.xaml.controls/webview.md) control can't be rendered into a [RenderTargetBitmap](rendertargetbitmap.md).
 + Content that can't be captured will appear as blank in the captured image, but other content in the same visual tree can still be captured and will render (the presence of content that can't be captured won't invalidate the entire capture of that XAML composition).
++ Content that's in the XAML visual tree but offscreen can be captured, so long as it's not [Visibility](../windows.ui.xaml/uielement_visibility.md) = **Collapsed** or in the other restricted cases.
 
 
 ## -examples


### PR DESCRIPTION
Ensures that information on `RenderTargetBitmap.RenderAsync` methods is consistent with the one present on the base `RenderTargetBitmap`.