### PR TITLE
Update broken "user" link

### DIFF
--- a/windows.gaming.xboxlive.storage/gamesaveprovider_getforuserasync_1027182495.md
+++ b/windows.gaming.xboxlive.storage/gamesaveprovider_getforuserasync_1027182495.md
@@ -16,7 +16,7 @@ Gets a game save provider for the specified user.
 ## -parameters
 ### -param user
 
-Type: [User](w_sys.user)
+Type: [User](windows.system.user)
 
 User who the game saves are for.
 


### PR DESCRIPTION
The user link seems to use an outdated address and leads to a 404 page. Updated with new url.