### PR TITLE
Replaces incorrect MediaElement references with MediaPlayerElement

### DIFF
--- a/windows.ui.xaml.controls/mediaplayerelement_aretransportcontrolsenabled.md
+++ b/windows.ui.xaml.controls/mediaplayerelement_aretransportcontrolsenabled.md
@@ -24,7 +24,7 @@ Gets or sets a value that determines whether the standard transport controls are
 ## -remarks
 The transport controls are exposed as a [MediaTransportControls](mediatransportcontrols.md) object that you can access through the [MediaPlayerElement.TransportControls](mediaplayerelement_transportcontrols.md) property. See [MediaTransportControls](mediatransportcontrols.md) for more info.
 
-If [AreTransportControlsEnabled](mediaelement_aretransportcontrolsenabled.md) is **true**, the standard transport controls are enabled and displayed on the [MediaPlayerElement](mediaplayerelement.md). If [AreTransportControlsEnabled](mediaelement_aretransportcontrolsenabled.md) is **false**, the standard transport controls are not enabled and are not displayed.
+If [AreTransportControlsEnabled](mediaplayerelement_aretransportcontrolsenabled.md) is **true**, the standard transport controls are enabled and displayed on the [MediaPlayerElement](mediaplayerelement.md). If [AreTransportControlsEnabled](mediaplayerelement_aretransportcontrolsenabled.md) is **false**, the standard transport controls are not enabled and are not displayed.
 
 The transport controls hide themselves after a short period of no user interaction with the [MediaPlayerElement](mediaplayerelement.md). They reappear when the user interacts with the [MediaPlayerElement](mediaplayerelement.md).
 

--- a/windows.ui.xaml.controls/mediaplayerelement_source.md
+++ b/windows.ui.xaml.controls/mediaplayerelement_source.md
@@ -10,7 +10,7 @@ public Windows.Media.Playback.IMediaPlaybackSource Source { get;  set; }
 # Windows.UI.Xaml.Controls.MediaPlayerElement.Source
 
 ## -description
-Gets or sets a media source on the [MediaElement](mediaelement.md).
+Gets or sets a media source on the [MediaPlayerElement](mediaplayerelement.md).
 
 ## -property-value
 The source of the media. The default is **null**.


### PR DESCRIPTION
Some instances of `MediaPlayerElement` documentation had incorrect pointers to `MediaElement`, this fixes it.