### PR TITLE
Remove unnecessary link

### DIFF
--- a/windows.ui.xaml.controls/checkbox.md
+++ b/windows.ui.xaml.controls/checkbox.md
@@ -10,7 +10,7 @@ public class CheckBox : Windows.UI.Xaml.Controls.Primitives.ToggleButton, Window
 # Windows.UI.Xaml.Controls.CheckBox
 
 ## -description
-Represents a control that a user can select (check) or clear (uncheck). A [CheckBox](checkbox.md) can also report its value as indeterminate.
+Represents a control that a user can select (check) or clear (uncheck). A CheckBox can also report its value as indeterminate.
 
 ## -xaml-syntax
 ```xaml


### PR DESCRIPTION
The description at the top of this page had a link to itself, which isn't helpful and a little confusing.