### PR TITLE
Specify Embedded mode is needed for systemManagement

### DIFF
--- a/windows.graphics.display/brightnessoverride_getdefaultforsystem_1452001692.md
+++ b/windows.graphics.display/brightnessoverride_getdefaultforsystem_1452001692.md
@@ -16,7 +16,7 @@ Returns a brightness override object. This method does not require [CoreWindow](
 The brightness override object.
 
 ## -remarks
-Requires the __systemManagement__ capability to be declared in your app's package manifest. This capability allows apps to have basic system administration privileges. If it isn’t declared, this method throws an access is denied exception. For more info, see [App capability declarations](https://docs.microsoft.com/windows/uwp/packaging/app-capability-declarations#general-use-capabilities).
+Requires the __systemManagement__ capability to be declared in your app's package manifest. Usage of the __systemManagement__ capability requires [Embedded mode](https://docs.microsoft.com/en-us/windows/iot-core/develop-your-app/embeddedmode) to be enabled. This capability allows apps to have basic system administration privileges. If it isn’t declared, this method throws an access is denied exception. For more info, see [App capability declarations](https://docs.microsoft.com/windows/uwp/packaging/app-capability-declarations#general-use-capabilities).
 
 ## -see-also
 


### PR DESCRIPTION
The documentation should specify that Embedded mode must be enabled to allow the systemManagement capability to be used.