### PR TITLE
First Example was missing for RelativePanel

### DIFF
--- a/windows.ui.xaml.controls/relativepanel.md
+++ b/windows.ui.xaml.controls/relativepanel.md
@@ -36,6 +36,7 @@ If your UI consists of multiple nested panels, [RelativePanel](relativepanel.md)
 Here's an example of a UI using a [RelativePanel](relativepanel.md) for its layout:
 
 <img alt="Relative panel control" src="images/controls/RelativePanelBasic.png" />
+
 ```xaml
 <RelativePanel BorderBrush="Gray" BorderThickness="10">
     <Rectangle x:Name="RedRect" Fill="Red" MinHeight="100" MinWidth="100"/>


### PR DESCRIPTION
Looks like lack of extra space caused code block not to render next to HTML img tag.