### PR TITLE
Update MediaElement to mention MediaOpened

### DIFF
--- a/windows.ui.xaml.controls/mediaelement_pause_1953642114.md
+++ b/windows.ui.xaml.controls/mediaelement_pause_1953642114.md
@@ -13,6 +13,7 @@ public void Pause()
 Pauses media at the current position.
 
 ## -remarks
+Any calls to [Play](mediaelement_play_848564459.md), [Pause](mediaelement_pause_1953642114.md), and [Stop](mediaelement_stop_1201535524.md) methods that occur before the [MediaOpened](mediaelement_mediaopened.md) event is raised are ignored.
 
 ## -examples
 

--- a/windows.ui.xaml.controls/mediaelement_play_848564459.md
+++ b/windows.ui.xaml.controls/mediaelement_play_848564459.md
@@ -13,6 +13,7 @@ public void Play()
 Plays media from the current position.
 
 ## -remarks
+Any calls to [Play](mediaelement_play_848564459.md), [Pause](mediaelement_pause_1953642114.md), and [Stop](mediaelement_stop_1201535524.md) methods that occur before the [MediaOpened](mediaelement_mediaopened.md) event is raised are ignored.
 
 ## -examples
 

--- a/windows.ui.xaml.controls/mediaelement_stop_1201535524.md
+++ b/windows.ui.xaml.controls/mediaelement_stop_1201535524.md
@@ -13,6 +13,7 @@ public void Stop()
 Stops and resets media to be played from the beginning.
 
 ## -remarks
+Any calls to [Play](mediaelement_play_848564459.md), [Pause](mediaelement_pause_1953642114.md), and [Stop](mediaelement_stop_1201535524.md) methods that occur before the [MediaOpened](mediaelement_mediaopened.md) event is raised are ignored.
 
 ## -examples
 


### PR DESCRIPTION
Ensure that docs for the `Play()`/`Pause()`/`Stop()` methods of `Windows.UI.Xaml.Controls.MediaElement` mention that those calls are ignored if the `MediaOpened` event has not been fired yet. This avoids the very confusing error where the user is not aware of this and calls those method anyway, only to find that the calls seems to randomly work solely depending on the timing of those calls relative to the event firing.

The change simply copies the remark from the `MediaOpened` docs into the docs for those 3 methods.
