### PR TITLE
Fix misspelled word.

### DIFF
--- a/windows.ui.composition.interactions/iinteractiontrackerowner_requestignored_1806693457.md
+++ b/windows.ui.composition.interactions/iinteractiontrackerowner_requestignored_1806693457.md
@@ -17,7 +17,7 @@ Callback that is triggered when the [InteractionTracker](interactiontracker.md) 
 The [InteractionTracker](interactiontracker.md) that triggered the callback.
 
 ### -param args
-The arguemtns for the callback.
+The arguments for the callback.
 
 ## -remarks
 


### PR DESCRIPTION
Fixing "arguments" under "param args" section.