### PR TITLE
FindPackagesForUserWithPackageTypes uses empty string not null

### DIFF
--- a/windows.management.deployment/packagemanager_findpackagesforuserwithpackagetypes_1110730286.md
+++ b/windows.management.deployment/packagemanager_findpackagesforuserwithpackagetypes_1110730286.md
@@ -14,7 +14,7 @@ Retrieves information about a specified family of packages and of specific types
 
 ## -parameters
 ### -param userSecurityId
-The user security identifier (SID). If this parameter is **null**, the packages are retrieved for the current user. Any user SID other than that of current user requires administrative privileges.
+The user security identifier (SID). If this parameter is **String.Empty**, the packages are retrieved for the current user. Any user SID other than that of current user requires administrative privileges.
 
 ### -param packageFamilyName
 The family name of packages to find. This parameter can't be **null**.


### PR DESCRIPTION
FindPackagesForUserWithPackageTypes throws an exception if userSecurityId is null. An empty string works to retrieve packages for the current user however.