### PR TITLE
Fix invalid reference to audio degradation in Windows.Media.Core.Vide…

### DIFF
--- a/windows.media.core/videotrack_supportinfo.md
+++ b/windows.media.core/videotrack_supportinfo.md
@@ -10,7 +10,7 @@ public Windows.Media.Core.VideoTrackSupportInfo SupportInfo { get; }
 # Windows.Media.Core.VideoTrack.SupportInfo
 
 ## -description
-Gets support information for the [VideoTrack](videotrack.md). This information includes the status of the video decoder, information about any audio degradation applied by the decoder, and the status of the [MediaSource](mediasource.md) with which the video track is associated.
+Gets support information for the [VideoTrack](videotrack.md). This information includes the status of the video decoder and the status of the [MediaSource](mediasource.md) with which the video track is associated.
 
 ## -property-value
 The support information for the [VideoTrack](videotrack.md).


### PR DESCRIPTION
…oTrackSupportInfo

This part was probably left after a copy/paste from AudioTrackSupportInfo documentation.
Please note that videotracksupportinfo.md file doesn't contain this invalid reference.