### PR TITLE
Remove XML comment

### DIFF
--- a/windows.ui.xaml/frameworkelement_setbinding_28713777.md
+++ b/windows.ui.xaml/frameworkelement_setbinding_28713777.md
@@ -10,9 +10,7 @@ public void SetBinding(Windows.UI.Xaml.DependencyProperty dp, Windows.UI.Xaml.Da
 # Windows.UI.Xaml.FrameworkElement.SetBinding
 
 ## -description
-Attaches a binding to a [FrameworkElement](frameworkelement.md), using the provided binding object
-<!--, and returns a <see cref="T:Windows.UI.Xaml.Data.BindingExpressionBase"/> for possible later use-->
-.
+Attaches a binding to a [FrameworkElement](frameworkelement.md), using the provided binding object.
 
 ## -parameters
 ### -param dp


### PR DESCRIPTION
The XML comment was showing up on a bing search preview, and created funny white space in the topic.

![image](https://user-images.githubusercontent.com/24882762/62088343-e789b900-b219-11e9-883f-a22db3a9ad5c.png)
