### PR TITLE
Include info on which XML this accepts and when

### DIFF
--- a/windows.networking.vpn/vpnmanagementagent_addprofilefromxmlasync_1803908060.md
+++ b/windows.networking.vpn/vpnmanagementagent_addprofilefromxmlasync_1803908060.md
@@ -10,9 +10,10 @@ public Windows.Foundation.IAsyncOperation<Windows.Networking.Vpn.VpnManagementEr
 # Windows.Networking.Vpn.VpnManagementAgent.AddProfileFromXmlAsync
 
 ## -description
-Creates a new VPN connection based on a [ProfileXML-encoded](https://docs.microsoft.com/en-us/windows/client-management/mdm/vpnv2-profile-xsd) string.
+Creates a new VPN connection based on a ProfileXML-encoded string (see [ProfileXML XSD](/windows/client-management/mdm/vpnv2-profile-xsd)).
 
 ## -parameters
+
 ### -param xml
 A **VpnProfile** object.
 
@@ -25,7 +26,6 @@ This method should only be used with versions of Windows as of the July 27 2019 
 ## -examples
 
 ## -see-also
-
 
 ## -capabilities
 networkingVpnProvider

--- a/windows.networking.vpn/vpnmanagementagent_addprofilefromxmlasync_1803908060.md
+++ b/windows.networking.vpn/vpnmanagementagent_addprofilefromxmlasync_1803908060.md
@@ -21,7 +21,7 @@ A **VpnProfile** object.
 An enum value indicating the error status.
 
 ## -remarks
-This method should only be used with versions of Windows as of the July 27 2019 update to the Windows 10 May 2019 Update. In prior versions of Windows, this method would simply return an error code and not add a profile.
+You should use this method only with a version of Windows with build number 18362.267, or later. The Windows 10 May 2019 Update (version 1903) has build number 18362; then, an update on July 27 2019 revised that build number to 18362.267. In build numbers prior to 18362.267, this method returns an error code, but does not add a profile.
 
 ## -examples
 

--- a/windows.networking.vpn/vpnmanagementagent_addprofilefromxmlasync_1803908060.md
+++ b/windows.networking.vpn/vpnmanagementagent_addprofilefromxmlasync_1803908060.md
@@ -10,7 +10,7 @@ public Windows.Foundation.IAsyncOperation<Windows.Networking.Vpn.VpnManagementEr
 # Windows.Networking.Vpn.VpnManagementAgent.AddProfileFromXmlAsync
 
 ## -description
-Creates a new VPN connection based on a WAP xml string for the VPNv2 CSP.
+Creates a new VPN connection based on a [ProfileXML-encoded](https://docs.microsoft.com/en-us/windows/client-management/mdm/vpnv2-profile-xsd) string.
 
 ## -parameters
 ### -param xml
@@ -20,6 +20,7 @@ A **VpnProfile** object.
 An enum value indicating the error status.
 
 ## -remarks
+This method should only be used with versions of Windows as of the July 27 2019 update to the Windows 10 May 2019 Update. In prior versions of Windows, this method would simply return an error code and not add a profile.
 
 ## -examples
 


### PR DESCRIPTION
We fixed the method in the Windows 10 May 2019 Updates (version 1903), build 18362.267 (the July 27 2019 update).
The XML was incorrectly named.

Note that this change requires an editor to make sure that (a) the link is fixed to match the actual markdown requirements and (b) that the remarks are properly formatted. There's one exact intermediate release at which point this method started to work; before then it didn't.