### PR TITLE
Fix Language description for IMediaTrack/AudioTrack/VideoTrack

### DIFF
--- a/windows.media.core/audiotrack_id.md
+++ b/windows.media.core/audiotrack_id.md
@@ -10,7 +10,7 @@ public string Id { get; }
 # Windows.Media.Core.AudioTrack.Id
 
 ## -description
-Gets or sets the identifier for the audio track.
+Gets the identifier for the audio track.
 
 ## -property-value
 The identifier for the audio track.

--- a/windows.media.core/audiotrack_language.md
+++ b/windows.media.core/audiotrack_language.md
@@ -10,7 +10,7 @@ public string Language { get; }
 # Windows.Media.Core.AudioTrack.Language
 
 ## -description
-Gets or sets a string indicating the language of the audio track.
+Gets a string indicating the language of the audio track.
 
 ## -property-value
 A string indicating the language of the audio track.

--- a/windows.media.core/imediatrack_language.md
+++ b/windows.media.core/imediatrack_language.md
@@ -10,7 +10,7 @@ public string Language { get; }
 # Windows.Media.Core.IMediaTrack.Language
 
 ## -description
-Gets or sets a string indicating the language of the media track.
+Gets a string indicating the language of the media track.
 
 ## -property-value
 A string indicating the language of the media track.

--- a/windows.media.core/sceneanalysiseffect_highdynamicrangeanalyzer.md
+++ b/windows.media.core/sceneanalysiseffect_highdynamicrangeanalyzer.md
@@ -10,7 +10,7 @@ public Windows.Media.Core.HighDynamicRangeControl HighDynamicRangeAnalyzer { get
 # Windows.Media.Core.SceneAnalysisEffect.HighDynamicRangeAnalyzer
 
 ## -description
-Gets or sets a [HighDynamicRangeControl](highdynamicrangecontrol.md) object that is used to enable or disable High Dynamic Range (HDR) analysis.
+Gets a [HighDynamicRangeControl](highdynamicrangecontrol.md) object that is used to enable or disable High Dynamic Range (HDR) analysis.
 
 ## -property-value
 A [HighDynamicRangeControl](highdynamicrangecontrol.md) object that is used to enable or disable High Dynamic Range (HDR) analysis.

--- a/windows.media.core/videotrack_id.md
+++ b/windows.media.core/videotrack_id.md
@@ -10,7 +10,7 @@ public string Id { get; }
 # Windows.Media.Core.VideoTrack.Id
 
 ## -description
-Gets or sets the identifier for the video track.
+Gets the identifier for the video track.
 
 ## -property-value
 The identifier for the video track.

--- a/windows.media.core/videotrack_language.md
+++ b/windows.media.core/videotrack_language.md
@@ -10,7 +10,7 @@ public string Language { get; }
 # Windows.Media.Core.VideoTrack.Language
 
 ## -description
-Gets or sets a string indicating the language of the video track.
+Gets a string indicating the language of the video track.
 
 ## -property-value
 A string indicating the language of the video track.


### PR DESCRIPTION
Language property is readonly, so its description should not imply
that this property can be set. Take the opportunity to fix similar
occurences in Windows.Media.Core