### PR TITLE
Added missing method argument to  AutomationProperties.SetHeadingLevel

### DIFF
--- a/windows.ui.xaml.automation/automationproperties_headinglevelproperty.md
+++ b/windows.ui.xaml.automation/automationproperties_headinglevelproperty.md
@@ -42,7 +42,7 @@ public sealed partial class MainPage : Page
     {
         this.InitializeComponent();
 
-        AutomationProperties.SetHeadingLevel(AutomationHeadingLevel.HeadingLevel3);
+        AutomationProperties.SetHeadingLevel(this, AutomationHeadingLevel.HeadingLevel3);
     }
 }
 


### PR DESCRIPTION
I added the missing DependencyElement argument to the sample code. Otherwise the code wouldn't compile. https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.automation.automationproperties.setheadinglevel