### PR TITLE
Use JumpListSystemGroupKind as property value

### DIFF
--- a/windows.ui.startscreen/jumplist_systemgroupkind.md
+++ b/windows.ui.startscreen/jumplist_systemgroupkind.md
@@ -13,7 +13,7 @@ public Windows.UI.StartScreen.JumpListSystemGroupKind SystemGroupKind { get;  se
 Gets or sets the current type of the system managed jump list group.
 
 ## -property-value
-The [JumpListItemKind](jumplistitemkind.md) enumeration value of the jump list.
+The [JumpListSystemGroupKind](jumplistsystemgroupkind.md) enumeration value of the jump list.
 
 ## -remarks
 


### PR DESCRIPTION
As mentioned in the issue below (and as the name of the property suggests), JumpListSystemGroupKind must be used instead 
of JumpListItemKind

Closes #1274