### PR TITLE
Add FontIcon.Glyph code-behind examples

### DIFF
--- a/windows.ui.xaml.controls/fonticon.md
+++ b/windows.ui.xaml.controls/fonticon.md
@@ -50,7 +50,7 @@ This example shows an [AppBarToggleButton](appbartogglebutton.md) with a FontIco
 ```csharp
 var newAppBarButton = new AppBarButton();
 var fontIcon = new FontIcon();
-fontIcon = new FontFamily("Segoe MDL2 Assets");
+fontIcon.FontFamily = new FontFamily("Segoe MDL2 Assets");
 fontIcon.Glyph = "\xE790";
 newAppBarButton.Icon = fontIcon;
 ```

--- a/windows.ui.xaml.controls/fonticon.md
+++ b/windows.ui.xaml.controls/fonticon.md
@@ -42,9 +42,28 @@ This example shows an [AppBarToggleButton](appbartogglebutton.md) with a FontIco
 ```xaml
 <AppBarToggleButton Label="FontIcon" Click="AppBarButton_Click">
     <AppBarToggleButton.Icon>
-        <FontIcon FontFamily="Candara" Glyph="&#x03A3;"/>
+        <FontIcon FontFamily="Segoe MDL2 Assets" Glyph="&#xE790;"/>
     </AppBarToggleButton.Icon>
 </AppBarToggleButton>
+```
+
+```csharp
+var newAppBarButton = new AppBarButton();
+var fontIcon = new FontIcon();
+fontIcon = new FontFamily("Segoe MDL2 Assets");
+fontIcon.Glyph = "\xE790";
+newAppBarButton.Icon = fontIcon;
+```
+
+```cppwinrt
+using namespace winrt::Windows::UI::Xaml;
+...
+
+auto newAppBarButton = Controls::AppBarButton{};
+auto fontIcon = Controls::FontIcon{};
+fontIcon.FontFamily(Media::FontFamily{ L"Segoe MDL2 Assets" });
+fontIcon.Glyph(L"\xE790");
+newAppBarButton.Icon(fontIcon);
 ```
 
 

--- a/windows.ui.xaml.controls/fonticon_glyph.md
+++ b/windows.ui.xaml.controls/fonticon_glyph.md
@@ -31,7 +31,7 @@ The hexadecimal character code for the icon glyph.
 ```csharp
 var newAppBarButton = new AppBarButton();
 var fontIcon = new FontIcon();
-fontIcon = new FontFamily("Segoe MDL2 Assets");
+fontIcon.FontFamily = new FontFamily("Segoe MDL2 Assets");
 fontIcon.Glyph = "\xE790";
 newAppBarButton.Icon = fontIcon;
 ```

--- a/windows.ui.xaml.controls/fonticon_glyph.md
+++ b/windows.ui.xaml.controls/fonticon_glyph.md
@@ -28,4 +28,23 @@ The hexadecimal character code for the icon glyph.
 
 ## -examples
 
+```csharp
+var newAppBarButton = new AppBarButton();
+var fontIcon = new FontIcon();
+fontIcon = new FontFamily("Segoe MDL2 Assets");
+fontIcon.Glyph = "\xE790";
+newAppBarButton.Icon = fontIcon;
+```
+
+```cppwinrt
+using namespace winrt::Windows::UI::Xaml;
+...
+
+auto newAppBarButton = Controls::AppBarButton{};
+auto fontIcon = Controls::FontIcon{};
+fontIcon.FontFamily(Media::FontFamily{ L"Segoe MDL2 Assets" });
+fontIcon.Glyph(L"\xE790");
+newAppBarButton.Icon(fontIcon);
+```
+
 ## -see-also


### PR DESCRIPTION
Since it is not very clear what format the Glyph property expects, this patch provides examples how to do it programmatically, e.g. in code-behind, viewmodel, etc. Code samples for C# and winrt/cpp are provided

Closes #1104