### PR TITLE
Fix DirectX11 example in iframeworkview.md

### DIFF
--- a/windows.applicationmodel.core/iframeworkview.md
+++ b/windows.applicationmodel.core/iframeworkview.md
@@ -287,7 +287,7 @@ private:
 
 int __stdcall wWinMain(HINSTANCE, HINSTANCE, PWSTR, int)
 {
-    CoreApplication::Run(App());
+    CoreApplication::Run(make<App>());
 }
 ```
 

--- a/windows.applicationmodel.core/iframeworkview.md
+++ b/windows.applicationmodel.core/iframeworkview.md
@@ -287,11 +287,11 @@ private:
 
 int __stdcall wWinMain(HINSTANCE, HINSTANCE, PWSTR, int)
 {
-    CoreApplication::Run(make<App>());
+    CoreApplication::Run(winrt::make<App>());
 }
 ```
 
-```cpp
+```cppcx
 ref class MyFrameworkView : public IFrameworkView
 {
 private:


### PR DESCRIPTION
Need to use `make` method to instantiate `App` otherwise you get `error C2259: 'App': cannot instantiate abstract class`