### PR TITLE
Update asymmetricalgorithmnames_ecdsap521sha512.md

### DIFF
--- a/windows.security.cryptography.core/asymmetricalgorithmnames_ecdsap521sha512.md
+++ b/windows.security.cryptography.core/asymmetricalgorithmnames_ecdsap521sha512.md
@@ -19,7 +19,7 @@ String that contains "ECDSA_P521_SHA512".
 Use the string retrieved by this property to set the asymmetric algorithm name when you call the [OpenAlgorithm](asymmetrickeyalgorithmprovider_openalgorithm_637226074.md) method. The string represents an Elliptic Curve Digital Signature Algorithm (ECDSA) that uses a 512-bit public key and a Secure Hashing Algorithm (SHA) to hash the message contents before signing. The length of the hash is 512 bits.
 
 > [!NOTE]
-> You must specify a value of 512 when calling the [CreateKeyPair](asymmetrickeyalgorithmprovider_createkeypair_920965104.md) method to create keys that are compatible with this algorithm.
+> You must specify a value of 521 when calling the [CreateKeyPair](asymmetrickeyalgorithmprovider_createkeypair_920965104.md) method to create keys that are compatible with this algorithm.
 
 ## -examples
 


### PR DESCRIPTION
For EcdsaP521Sha512, the key length is 521.  Calling CreateKeyPair with 512 results in an invalid value