### PR TITLE
Update Vpn Package Family Name to note required field and add helpful remark

### DIFF
--- a/windows.networking.vpn/vpnpluginprofile_vpnpluginpackagefamilyname.md
+++ b/windows.networking.vpn/vpnpluginprofile_vpnpluginpackagefamilyname.md
@@ -10,17 +10,17 @@ public string VpnPluginPackageFamilyName { get;  set; }
 # Windows.Networking.Vpn.VpnPlugInProfile.VpnPluginPackageFamilyName
 
 ## -description
-Gets or sets the package family name of the VPN plug-in to be used for this VPN plug-in profile.
+Gets or sets the package family name of the VPN plug-in to be used for this VPN plug-in profile. This field is required for VpnPlugInProfile to be valid.
 
 ## -property-value
 The package family name of the VPN plug-in to be used for this VPN plug-in profile.
 
 ## -remarks
+If creating or modifying a VPN plug-in profile from the App that is the VPN plug-in, [Package.Current.Id.FamilyName](../windows.applicationmodel/package_current.md) can be used to easily obtain the current package family name at run time.
 
 ## -examples
 
 ## -see-also
-
 
 ## -capabilities
 networkingVpnProvider

--- a/windows.networking.vpn/vpnpluginprofile_vpnpluginpackagefamilyname.md
+++ b/windows.networking.vpn/vpnpluginprofile_vpnpluginpackagefamilyname.md
@@ -22,5 +22,6 @@ If creating or modifying a VPN plug-in profile from the App that is the VPN plug
 
 ## -see-also
 
+
 ## -capabilities
 networkingVpnProvider


### PR DESCRIPTION

Update vpnpluginprofile_vpnpluginpackagefamilyname.md to note that this field is required to for a VpnPlugInProfile to be valid.

Also, add a remark that helps developers get a valid value if they are creating a profile from the plug-in.