### PR TITLE
Fix the example of ManipulationDelta.Scale

### DIFF
--- a/windows.ui.input/manipulationdelta.md
+++ b/windows.ui.input/manipulationdelta.md
@@ -20,7 +20,7 @@ The change in x-y screen coordinates, in device-independent pixel (DIP).
 
 ### -field Scale
 
-The change in distance between touch contacts, as a percentage. For example, if the distance between two contacts changes from 100 device-independent pixel (DIP) to 200 device-independent pixel (DIP) during a manipulation, the value of **Scale** would be 1.0.
+The change in distance between touch contacts, as a percentage. For example, if the distance between two contacts changes from 100 device-independent pixel (DIP) to 200 device-independent pixel (DIP) during a manipulation, the value of **Scale** would be 2.0.
 
 ### -field Rotation
 


### PR DESCRIPTION
According to my test, the **Scale** is indeed a percentage of the distance, but it's `original * scale = current` and not `original * (1.0 + scale) = current` as stated in the example.