### PR TITLE
Update sample code to remove incorrect variable

### DIFF
--- a/windows.ui.xaml/dependencyobject_registerpropertychangedcallback_1557279748.md
+++ b/windows.ui.xaml/dependencyobject_registerpropertychangedcallback_1557279748.md
@@ -40,7 +40,7 @@ This example shows how to use a [DependencyPropertyChangedCallback](dependencypr
 long tagToken;
 protected override void OnNavigatedTo(NavigationEventArgs e)
 {
-    long tagToken = textBlock1.RegisterPropertyChangedCallback(TextBlock.TagProperty, tbTagChangedCallback);
+    tagToken = textBlock1.RegisterPropertyChangedCallback(TextBlock.TagProperty, tbTagChangedCallback);
     base.OnNavigatedTo(e);
 
     textBlock1.Tag = "name";


### PR DESCRIPTION
The sample code redeclares a class level variable inside the OnNavigatedTo method. 

This means that the OnNavigatedFrom method wouldn't actually have access to the value returned from RegisterPropertyChangedCallback and could not, therefore, properly unregister to the callback.