### PR TITLE
Remove winui tech from the Windows.UI.** namespace

### DIFF
--- a/docfx.json
+++ b/docfx.json
@@ -289,7 +289,6 @@
       },
       "ms.technology":
       {
-        "windows.ui**.yml": "winui",
         "windows.ui.xaml**.yml": "winui",
         "windows.ui.xaml.automation**.yml": "winui",
         "windows.ui.xaml.controls.maps**.yml": "winui",


### PR DESCRIPTION
The Windows.UI, Windows.UI.Core, etc namespaces are general WinRT. Only Windows.UI.Xaml.* is WinUI.