### PR TITLE
Add file contents to FileSavePicker JavaScript example

### DIFF
--- a/windows.storage.pickers/code/FilePicker/js/js/scenario4.js
+++ b/windows.storage.pickers/code/FilePicker/js/js/scenario4.js
@@ -13,7 +13,7 @@
         }
     });
 
-    function saveFile() {
+    function saveFile(fileContents) {
         // Clean scenario output
         WinJS.log && WinJS.log("", "sample", "status");
 
@@ -48,7 +48,7 @@
                 // Prevent updates to the remote version of the file until we finish making changes and call CompleteUpdatesAsync.
                 Windows.Storage.CachedFileManager.deferUpdates(file);
                 // write to file
-                Windows.Storage.FileIO.writeTextAsync(file, file.name).done(function () {
+                Windows.Storage.FileIO.writeTextAsync(file, fileContents).done(function () {
                     // Let Windows know that we're finished changing the file so the other app can update the remote version of the file.
                     // Completing updates may require Windows to ask for user input.
                     Windows.Storage.CachedFileManager.completeUpdatesAsync(file).done(function (updateStatus) {


### PR DESCRIPTION
The original code included no way of actually specifying a string as the file contents. Instead, it would store the file name as the contents of the file which is a valid example but is confusing as it looks like the second argument of `Windows.Storage.FileIO.writeTextAsync` is the file name itself and not the contents.

 This change adds the file contents as an input to the example `safeFile` function and saves it in the user-selected file.