### PR TITLE
Update rfcommserviceprovider_createasync_725413930.md

### DIFF
--- a/windows.devices.bluetooth.rfcomm/rfcommserviceprovider_createasync_725413930.md
+++ b/windows.devices.bluetooth.rfcomm/rfcommserviceprovider_createasync_725413930.md
@@ -11,7 +11,7 @@ public Windows.Foundation.IAsyncOperation<Windows.Devices.Bluetooth.Rfcomm.Rfcom
 # Windows.Devices.Bluetooth.Rfcomm.RfcommServiceProvider.CreateAsync
 
 ## -description
-Gets a RfcommServiceProvider object from a [DeviceInformation](../windows.devices.enumeration/deviceinformation.md) Id for a RFCOMM service instance.
+Gets a RfcommServiceProvider object from a [RfcommServiceId](rfcommserviceid.md) for an RFCOMM service instance.
 
 ## -parameters
 ### -param serviceId


### PR DESCRIPTION
Corrected parameter link from DeviceInformation to RfCommServiceId (this represents the service UUID for the Bluetooth service to be advertised and will be either a Bluetooth defined identifier or a custom UUID).