### PR TITLE
Clarify documenation for MediaFrameReference intrinsics and extrinsics

### DIFF
--- a/windows.media.devices.core/cameraintrinsics_principalpoint.md
+++ b/windows.media.devices.core/cameraintrinsics_principalpoint.md
@@ -16,6 +16,7 @@ Gets the principal point of the camera.
 The principal point of the camera.
 
 ## -remarks
+The principal point is expressed in pixels, not in normalized coordinates. The origin [0,0] is the bottom, left corner of the image (+Y pointing up). Note that this differs from typical image coordinates which have the origin in the top, left corner of the image (+Y pointing down).
 
 ## -examples
 

--- a/windows.media.devices.core/cameraintrinsics_projectmanyontoframe_706628651.md
+++ b/windows.media.devices.core/cameraintrinsics_projectmanyontoframe_706628651.md
@@ -20,6 +20,7 @@ The array of camera space points to project into screen space.
 The array of screen space pixel coordinates.
 
 ## -remarks
+The 3D coordinates must be expressed in meters, using a left-handed coordinate system, with +X pointing right, +Y pointing up, and +Z pointing forward out from the camera through the center (principal point) of the image. The resulting 2D coordinates will be expressed in pixels, with the origin in the top-left corner of the image; that is, +X pointing right, and +Y pointing down.
 
 ## -examples
 

--- a/windows.media.devices.core/cameraintrinsics_projectontoframe_368534707.md
+++ b/windows.media.devices.core/cameraintrinsics_projectontoframe_368534707.md
@@ -20,6 +20,7 @@ The camera space point to project into screen space.
 The screen space pixel coordinates.
 
 ## -remarks
+The 3D coordinate must be expressed in meters, using a left-handed coordinate system, with +X pointing right, +Y pointing up, and +Z pointing forward out from the camera through the center (principal point) of the image. The resulting 2D coordinate will be expressed in pixels, with the origin in the top-left corner of the image; that is, +X pointing right, and +Y pointing down.
 
 ## -examples
 

--- a/windows.media.devices.core/cameraintrinsics_undistortedprojectiontransform.md
+++ b/windows.media.devices.core/cameraintrinsics_undistortedprojectiontransform.md
@@ -16,7 +16,12 @@ Gets a matrix that transforms a 3D point to video frame pixel coordinates withou
 Gets a matrix that transforms a 3D point to the video frame pixel coordinates without compensating for the distortion model of the camera.
 
 ## -remarks
+The transform converts from a left-handed 3D coordinate system in meters with +X pointing right, +Y pointing up, and +Z pointing forward out from the camera through the center (principal point) of the image, to a 2D coordinate system in pixels with the origin at the top-left corner of the image, and +X pointing to the right, and +Y pointing down.
 
+<div class="alert"><b>Important</b>
+  <p class="note">This transform will only produce correct results for 3D coordinates with Z=1.0. To produce a transform which will work for 3D coordinates with arbitrary Z values, swap the third and fourth rows of the matrix.
+</div>
+  
 ## -examples
 
 ## -see-also

--- a/windows.media.devices.core/cameraintrinsics_undistortedprojectiontransform.md
+++ b/windows.media.devices.core/cameraintrinsics_undistortedprojectiontransform.md
@@ -68,7 +68,7 @@ void ProjectCameraCoordinatesToPixelCoordinates(
         rightToLeft * undistortedProjectionTransform);
 
     std::transform(pixelCoordinateVectors.begin(), pixelCoordinateVectors.end(), pixelCoordinates.begin(),
-        [](const XMFLOAT4& v) { return winrt::Windows::Foundation::Point{ v.x, v.y }; });
+        [](const XMFLOAT3& v) { return winrt::Windows::Foundation::Point{ v.x, v.y }; });
 }
 ```
   

--- a/windows.media.devices.core/cameraintrinsics_undistortedprojectiontransform.md
+++ b/windows.media.devices.core/cameraintrinsics_undistortedprojectiontransform.md
@@ -10,17 +10,67 @@ public Windows.Foundation.Numerics.Matrix4x4 UndistortedProjectionTransform { ge
 # Windows.Media.Devices.Core.CameraIntrinsics.UndistortedProjectionTransform
 
 ## -description
-Gets a matrix that transforms a 3D point to video frame pixel coordinates without compensating for the distortion model of the camera. The 2D point resulting from this transformation will not accurately map to the pixel coordinate in a video frame unless the app applies its own distortion compensation.   This is useful for apps that choose to implement GPU-based distortion compensation instead of using [UndistortPoint](https://docs.microsoft.com/uwp/api/windows.media.devices.core.cameraintrinsics#Windows_Media_Devices_Core_CameraIntrinsics_UndistortPoint_Windows_Foundation_Point_), which uses the CPU to compute the distortion compensation.
+Gets a matrix that transforms a 2D coordinate in meters on the image plane to video frame pixel coordinates without compensating for the distortion model of the camera. The 2D point resulting from this transformation will not accurately map to the pixel coordinate in a video frame unless the app applies its own distortion compensation.   This is useful for apps that choose to implement GPU-based distortion compensation instead of using [UndistortPoint](https://docs.microsoft.com/uwp/api/windows.media.devices.core.cameraintrinsics#Windows_Media_Devices_Core_CameraIntrinsics_UndistortPoint_Windows_Foundation_Point_), which uses the CPU to compute the distortion compensation.
 
 ## -property-value
-Gets a matrix that transforms a 3D point to the video frame pixel coordinates without compensating for the distortion model of the camera.
+Gets a matrix that transforms a 2D coordinate in meters on the image plane to the video frame pixel coordinates without compensating for the distortion model of the camera.
 
 ## -remarks
-The transform converts from a left-handed 3D coordinate system in meters with +X pointing right, +Y pointing up, and +Z pointing forward out from the camera through the center (principal point) of the image, to a 2D coordinate system in pixels with the origin at the top-left corner of the image, and +X pointing to the right, and +Y pointing down.
+The transform converts from a 2D coordinate in meters on the image plane (origin at the principal point, +X pointing to the right and +Y pointing up), to a 2D coordinate in pixels with the origin at the top-left corner of the image, and +X pointing to the right, and +Y pointing down. If the 2D coordinate is expressed as a vector with four components, Z must be set to 0 and W must set to 1.
 
-<div class="alert"><b>Important</b>
-  <p class="note">This transform will only produce correct results for 3D coordinates with Z=1.0. To produce a transform which will work for 3D coordinates with arbitrary Z values, swap the third and fourth rows of the matrix.
-</div>
+To convert a 3D coordinate in the camera's coordinate system to pixel coordinates, the X and Y components of the coordinate must first be divided by the distance from the camera (i.e. the Z coordinate) to project them onto the image plane. Note that camera coordinate systems are right-handed by convention, with +X pointing right, +Y pointing up, and -Z pointing out from the camera through the center (principal point) of the image. In that convention, the Z coordinate must be negated when dividing into the X and Y components. For example:
+
+```cpp
+using namespace winrt::Windows::Foundation::Numerics;
+winrt::Windows::Foundation::Point ProjectCameraCoordinateToPixelCoordinate(
+    const winrt::Windows::Media::Devices::Core::CameraIntrinsics& cameraIntrinsics,
+    const float3& cameraCoordinate)
+{
+    const float2 imagePlaneCoordinate = float2{ cameraCoordinate.x / -cameraCoordinate.z, cameraCoordinate.y / -cameraCoordinate.z };
+    float2 pixelCoordinate = transform(imagePlaneCoordinate, cameraIntrinsics.UndistortedProjectionTransform());
+    return winrt::Windows::Foundation::Point{ pixelCoordinate.x, pixelCoordinate.y };
+}
+```
+
+An equivalent result can be acheived using a vector with four components by setting the Z component to 1 and the W component to the distance from the camera. Note that the resulting X and Y components must be divided by the resulting W component to yield the final pixel coordinates:
+
+```cpp
+using namespace winrt::Windows::Foundation::Numerics;
+winrt::Windows::Foundation::Point ProjectCameraCoordinateToPixelCoordinate(
+    const winrt::Windows::Media::Devices::Core::CameraIntrinsics& cameraIntrinsics,
+    const float3& cameraCoordinate)
+{
+    float4 cameraCoordinateVector{ cameraCoordinate.x, cameraCoordinate.y, 1, -cameraCoordinate.z };
+    float4 pixelCoordinate = transform(cameraCoordinateVector, cameraIntrinsics.UndistortedProjectionTransform());
+    return winrt::Windows::Foundation::Point{ pixelCoordinate.x / pixelCoordinate.w, pixelCoordinate.y / pixelCoordinate.w };
+}
+```
+
+If this transform will be applied to many 3D coordinates, it may be more convenient to adjust the matrix itself, rather than each input coordinate. This can be accomplished by swapping the third and fourth rows of the matrix, and using a homogeneous coordinate transform function like <a href="https://docs.microsoft.com/en-us/windows/win32/api/directxmath/nf-directxmath-xmvector3transformcoordstream">XMVector3TransformCoordStream</a>. Note that a right-handed-to-left-handed conversion is also applied as part of the transform so that the distance from the camera is a positive value:
+
+```cpp
+using namespace DirectX;
+void ProjectCameraCoordinatesToPixelCoordinates(
+    const winrt::Windows::Media::Devices::Core::CameraIntrinsics& cameraIntrinsics,
+    const winrt::array_view<XMFLOAT3>& cameraCoordinates,
+    winrt::array_view<winrt::Windows::Foundation::Point>& pixelCoordinates)
+{
+    XMMATRIX undistortedProjectionTransform = XMLoadFloat4x4(&cameraIntrinsics.UndistortedProjectionTransform());
+    std::swap(undistortedProjectionTransform.r[2], undistortedProjectionTransform.r[3]);
+
+    // convert right-handed coordinates (-Z forward) to right-handed coordinates (+Z forward) as part of the transform
+    static const XMMATRIX rightToLeft = XMMatrixScaling(1, 1, -1);
+
+    std::vector<XMFLOAT3> pixelCoordinateVectors(cameraCoordinates.size());
+    XMVector3TransformCoordStream(
+        pixelCoordinateVectors.data(), sizeof(pixelCoordinateVectors[0]),
+        cameraCoordinates.data(), sizeof(cameraCoordinates[0]), cameraCoordinates.size(),
+        rightToLeft * undistortedProjectionTransform);
+
+    std::transform(pixelCoordinateVectors.begin(), pixelCoordinateVectors.end(), pixelCoordinates.begin(),
+        [](const XMFLOAT4& v) { return winrt::Windows::Foundation::Point{ v.x, v.y }; });
+}
+```
   
 ## -examples
 

--- a/windows.media.devices.core/cameraintrinsics_unprojectatunitdepth_1064040166.md
+++ b/windows.media.devices.core/cameraintrinsics_unprojectatunitdepth_1064040166.md
@@ -20,7 +20,7 @@ The pixel coordinates to unproject into camera space.
 The X, Y coordinates of the unprojected pixel on the plane at Z = 1.0.
 
 ## -remarks
-The image coordinate must be expressed in pixels, with the origin in the top-left corner of the image; that is, +X pointing right, and +Y pointing down. The unprojected coordinate will be expressed in meters, using a left-handed coordinate system, with +X pointing right, +Y pointing up, and +Z pointing forward out from a plane located at the center (principal point) of the image, one meter away from the camera.
+The image coordinate must be expressed in pixels, with the origin in the top-left corner of the image; that is, +X pointing right, and +Y pointing down. The unprojected coordinate will be expressed in meters, with +X pointing right, and +Y pointing up, on a plane located at the center (principal point) of the image, one meter away from the camera.
 
 ## -examples
 

--- a/windows.media.devices.core/cameraintrinsics_unprojectatunitdepth_1064040166.md
+++ b/windows.media.devices.core/cameraintrinsics_unprojectatunitdepth_1064040166.md
@@ -10,14 +10,14 @@ public Windows.Foundation.Numerics.Vector2 UnprojectAtUnitDepth(Windows.Foundati
 # Windows.Media.Devices.Core.CameraIntrinsics.UnprojectAtUnitDepth
 
 ## -description
-Unprojects pixel coordinates into a camera space ray from the camera origin, expressed as a X, Y coordinates on the plane at Z = 1.0.
+Unprojects pixel coordinates into a camera space ray from the camera origin, expressed as a X, Y coordinates on a plane one meter from the camera.
 
 ## -parameters
 ### -param pixelCoordinate
 The pixel coordinates to unproject into camera space.
 
 ## -returns
-The X, Y coordinates of the unprojected pixel on the plane at Z = 1.0.
+The X, Y coordinates of the unprojected pixel on a plane one meter from the camera.
 
 ## -remarks
 The image coordinate must be expressed in pixels, with the origin in the top-left corner of the image; that is, +X pointing right, and +Y pointing down. The unprojected coordinate will be expressed in meters, with +X pointing right, and +Y pointing up, on a plane located at the center (principal point) of the image, one meter away from the camera.

--- a/windows.media.devices.core/cameraintrinsics_unprojectatunitdepth_1064040166.md
+++ b/windows.media.devices.core/cameraintrinsics_unprojectatunitdepth_1064040166.md
@@ -20,6 +20,7 @@ The pixel coordinates to unproject into camera space.
 The X, Y coordinates of the unprojected pixel on the plane at Z = 1.0.
 
 ## -remarks
+The image coordinate must be expressed in pixels, with the origin in the top-left corner of the image; that is, +X pointing right, and +Y pointing down. The unprojected coordinate will be expressed in meters, using a left-handed coordinate system, with +X pointing right, +Y pointing up, and +Z pointing forward out from a plane located at the center (principal point) of the image, one meter away from the camera.
 
 ## -examples
 

--- a/windows.media.devices.core/cameraintrinsics_unprojectpixelsatunitdepth_1708320502.md
+++ b/windows.media.devices.core/cameraintrinsics_unprojectpixelsatunitdepth_1708320502.md
@@ -10,7 +10,7 @@ public void UnprojectPixelsAtUnitDepth(Windows.Foundation.Point[] pixelCoordinat
 # Windows.Media.Devices.Core.CameraIntrinsics.UnprojectPixelsAtUnitDepth
 
 ## -description
-Unprojects an array pixel coordinates into a camera space rays from the camera origin, expressed as a X, Y coordinates on a plane one meter from the camera.
+Unprojects an array of pixel coordinates into an array of camera space rays from the camera origin, expressed as a X, Y coordinates on a plane one meter from the camera.
 
 ## -parameters
 ### -param pixelCoordinates

--- a/windows.media.devices.core/cameraintrinsics_unprojectpixelsatunitdepth_1708320502.md
+++ b/windows.media.devices.core/cameraintrinsics_unprojectpixelsatunitdepth_1708320502.md
@@ -10,14 +10,14 @@ public void UnprojectPixelsAtUnitDepth(Windows.Foundation.Point[] pixelCoordinat
 # Windows.Media.Devices.Core.CameraIntrinsics.UnprojectPixelsAtUnitDepth
 
 ## -description
-Unprojects an array pixel coordinates into a camera space rays from the camera origin, expressed as a X, Y coordinates on the plane at Z = 1.0.
+Unprojects an array pixel coordinates into a camera space rays from the camera origin, expressed as a X, Y coordinates on a plane one meter from the camera.
 
 ## -parameters
 ### -param pixelCoordinates
 The array of pixel coordinates to unproject into camera space.
 
 ### -param results
-The array of X, Y coordinates of the unprojected pixels on the plane at Z = 1.0.
+The array of X, Y coordinates of the unprojected pixels on a plane one meter from the camera.
 
 ## -remarks
 The image coordinates must be expressed in pixels, with the origin in the top-left corner of the image; that is, +X pointing right, and +Y pointing down. The unprojected coordinates will be expressed in meters, with +X pointing right, and +Y pointing up,on a plane located at the center (principal point) of the image, one meter away from the camera.

--- a/windows.media.devices.core/cameraintrinsics_unprojectpixelsatunitdepth_1708320502.md
+++ b/windows.media.devices.core/cameraintrinsics_unprojectpixelsatunitdepth_1708320502.md
@@ -20,6 +20,7 @@ The array of pixel coordinates to unproject into camera space.
 The array of X, Y coordinates of the unprojected pixels on the plane at Z = 1.0.
 
 ## -remarks
+The image coordinates must be expressed in pixels, with the origin in the top-left corner of the image; that is, +X pointing right, and +Y pointing down. The unprojected coordinates will be expressed in meters, with +X pointing right, and +Y pointing up,on a plane located at the center (principal point) of the image, one meter away from the camera.
 
 ## -examples
 


### PR DESCRIPTION
Added details to clarify the semantics of the APIs for handling camera intrinsics and extrinsics for a MediaFrameReference.