### PR TITLE
Mention limited support for Variants

### DIFF
--- a/windows.ui.xaml/fontvariants.md
+++ b/windows.ui.xaml/fontvariants.md
@@ -10,6 +10,7 @@ public enum Windows.UI.Xaml.FontVariants : int
 # FontVariants
 
 ## -description
+
 Describes a font variant value for the [Typography.Variants](/uwp/api/windows.ui.xaml.documents.typography#xaml-attached-properties) attached property.
 
 ## -xaml-syntax
@@ -18,33 +19,42 @@ Describes a font variant value for the [Typography.Variants](/uwp/api/windows.ui
  
 ```
 
-
 ## -enum-fields
+
 ### -field Normal:0
+
 Default font behavior. Font scaling and positioning is normal.
 
 ### -field Superscript:1
+
 Replaces a default glyph with a superscript glyph. Superscript is commonly used for footnotes.
 
 ### -field Subscript:2
+
 Replaces a default glyph with a subscript glyph.
 
 ### -field Ordinal:3
+
 Replaces a default glyph with an ordinal glyph, or it may combine glyph substitution with positioning adjustments for proper placement. Ordinal forms are normally associated with numeric notation of an ordinal word, such as "1st" for "first".
 
 ### -field Inferior:4
+
 Replaces a default glyph with an inferior glyph, or it may combine glyph substitution with positioning adjustments for proper placement. Inferior forms are typically used in chemical formulas or mathematical notation.
 
 ### -field Ruby:5
+
 Replaces a default glyph with a smaller Japanese Kana glyph. This is used to clarify the meaning of Kanji, which may be unfamiliar to the reader.
 
-
 ## -remarks
+
 This enumeration is used by the [Typography.Variants](/uwp/api/windows.ui.xaml.documents.typography#xaml-attached-properties) attached property.
 
-Fonts that do not support variants may have an algorithmic approximation of the font form, or may ignore the Variants setting. Variants may also only be supported for a subset of characters in a font.
+Some fonts might support a subset of variant values, or ignore the setting completely.
+
+Some fonts might also algorithmically approximate a font form instead of supporting [Typography.Variants](/uwp/api/windows.ui.xaml.documents.typography#xaml-attached-properties). 
 
 ## -examples
 
 ## -see-also
+
 [Typography](../windows.ui.xaml.documents/typography.md)

--- a/windows.ui.xaml/fontvariants.md
+++ b/windows.ui.xaml/fontvariants.md
@@ -42,6 +42,8 @@ Replaces a default glyph with a smaller Japanese Kana glyph. This is used to cla
 ## -remarks
 This enumeration is used by the [Typography.Variants](/uwp/api/windows.ui.xaml.documents.typography#xaml-attached-properties) attached property.
 
+Fonts that do not support variants may have an algorithmic approximation of the font form, or may ignore the Variants setting. Variants may also only be supported for a subset of characters in a font.
+
 ## -examples
 
 ## -see-also

--- a/windows.ui.xaml/fontvariants.md
+++ b/windows.ui.xaml/fontvariants.md
@@ -35,15 +35,15 @@ Replaces a default glyph with a subscript glyph.
 
 ### -field Ordinal:3
 
-Replaces a default glyph with an ordinal glyph, or it may combine glyph substitution with positioning adjustments for proper placement. Ordinal forms are normally associated with numeric notation of an ordinal word, such as "1st" for "first".
+Replaces a default glyph with an ordinal glyph, or it might combine glyph substitution with positioning adjustments for proper placement. Ordinal forms are normally associated with numeric notation of an ordinal word, such as "1st" for "first".
 
 ### -field Inferior:4
 
-Replaces a default glyph with an inferior glyph, or it may combine glyph substitution with positioning adjustments for proper placement. Inferior forms are typically used in chemical formulas or mathematical notation.
+Replaces a default glyph with an inferior glyph, or it might combine glyph substitution with positioning adjustments for proper placement. Inferior forms are typically used in chemical formulas or mathematical notation.
 
 ### -field Ruby:5
 
-Replaces a default glyph with a smaller Japanese Kana glyph. This is used to clarify the meaning of Kanji, which may be unfamiliar to the reader.
+Replaces a default glyph with a smaller Japanese Kana glyph. This is used to clarify the meaning of Kanji, which might be unfamiliar to the reader.
 
 ## -remarks
 


### PR DESCRIPTION
Per https://github.com/microsoft/microsoft-ui-xaml/issues/1957, it was noticed that UWP XAML doesn't support Superscript for all characters in all fonts. This update mentions the limitation, starting with a limitation note from the WPF documentation and then further clarifying that the setting my have no effect for some characters.