### PR TITLE
Update threading description

### DIFF
--- a/windows.ui.xaml/window_current.md
+++ b/windows.ui.xaml/window_current.md
@@ -10,12 +10,13 @@ public Windows.UI.Xaml.Window Current { get; }
 # Windows.UI.Xaml.Window.Current
 
 ## -description
-Gets the currently activated window for an application.
+Gets the window of the current thread.
 
 ## -property-value
 The currently activated window.
 
 ## -remarks
+The value of this property depends on the thread from which it is called. If called from a UI thread, this the value is the Window instance for that thread. On any other thread the value is null.
 
 ## -examples
 

--- a/windows.ui.xaml/window_current.md
+++ b/windows.ui.xaml/window_current.md
@@ -16,7 +16,7 @@ Gets the window of the current thread.
 The currently activated window.
 
 ## -remarks
-The value of this property depends on the thread from which it is called. If called from a UI thread, this the value is the Window instance for that thread. On any other thread the value is null.
+The value of this property depends on the thread from which it is called. If called from a UI thread, the value is the Window instance for that thread. On any other thread, the value is `null`.
 
 ## -examples
 


### PR DESCRIPTION
The current text says that this returns the active window, which would mean whatever window in the app has keyboard focus. Actually it returns whatever Window is on the calling thread (or null).