### PR TITLE
Update link to Web authentication broker sample

### DIFF
--- a/windows.security.authentication.web/webauthenticationbroker.md
+++ b/windows.security.authentication.web/webauthenticationbroker.md
@@ -11,7 +11,7 @@ public class WebAuthenticationBroker
 
 ## -description
 
-Starts the authentication operation. You can call the methods of this class multiple times in a single application or across multiple applications at the same time. The [Web authentication broker sample](https://code.msdn.microsoft.com/windowsapps/Web-Authentication-d0485122) in the Samples gallery is an example of how to use the WebAuthenticationBroker class for single sign on (SSO) connections.
+Starts the authentication operation. You can call the methods of this class multiple times in a single application or across multiple applications at the same time. The [Web authentication broker sample](https://github.com/microsoft/Windows-universal-samples/tree/master/Samples/WebAuthenticationBroker) in the Samples gallery is an example of how to use the WebAuthenticationBroker class for single sign on (SSO) connections.
 
 ## -remarks
 


### PR DESCRIPTION
The previous link: https://code.msdn.microsoft.com/windowsapps/Web-Authentication-d0485122 is dead. updating link to point to the Windows 10 universal sample page for web authentication broker.