### PR TITLE
Update downloadoperation_pause_1953642114.md

### DIFF
--- a/windows.networking.backgroundtransfer/downloadoperation_pause_1953642114.md
+++ b/windows.networking.backgroundtransfer/downloadoperation_pause_1953642114.md
@@ -13,7 +13,7 @@ public void Pause()
 Pauses a download operation.
 
 ## -remarks
-Calling this method will abort the HTTP request but preserve state for the download and the partially downloaded response. This method will fail when called for operations that haven't been started yet, are already paused, or use POST requests. Use the Progress property's Status value to detect when the operation is fully paused (the status will no longer be Running). This is important if you need to pause an operation and then change the SetRequestedUri; the change can't be made while the Status is Running.
+Calling this method aborts the HTTP request, but preserves state for the download and for the partially downloaded response. This method fails when called for an operation that either: hasn't been started yet; is already paused; or that uses a POST request. To detect when the operation is fully paused, get the value of the [Progress property](/uwp/api/windows.networking.backgroundtransfer.downloadoperation.progress), and then access the [Status field](/uwp/api/windows.networking.backgroundtransfer.backgrounddownloadprogress.status) of that value. When the operation is fully paused, the *Status* field's value will no longer be **Running**. This is important if you need to pause an operation and then change [RequestedUri](/uwp/api/windows.networking.backgroundtransfer.downloadoperation.requesteduri), because you can't make that change while the the *Status* field's value is **Running**.
 
 ## -examples
 

--- a/windows.networking.backgroundtransfer/downloadoperation_pause_1953642114.md
+++ b/windows.networking.backgroundtransfer/downloadoperation_pause_1953642114.md
@@ -13,7 +13,7 @@ public void Pause()
 Pauses a download operation.
 
 ## -remarks
-Calling this method will abort the HTTP request but preserve state for the download and the partially downloaded response. This method will fail when called for operations that haven't been started yet, are already paused, or use POST requests.
+Calling this method will abort the HTTP request but preserve state for the download and the partially downloaded response. This method will fail when called for operations that haven't been started yet, are already paused, or use POST requests. Use the Progress property's Status value to detect when the operation is fully paused (the status will no longer be Running). This is important if you need to pause an operation and then change the SetRequestedUri; the change can't be made while the Status is Running.
 
 ## -examples
 


### PR DESCRIPTION
Added a clarification for an uncommon situation: the pause request is queued up right away, but doesn't take effect until later. This can be i important when trying to pause an operation in order to make changes.