### PR TITLE
Document interpretation of axis-angle quantities

### DIFF
--- a/windows.perception.spatial/spatiallocation_absoluteangularaccelerationaxisangle.md
+++ b/windows.perception.spatial/spatiallocation_absoluteangularaccelerationaxisangle.md
@@ -17,7 +17,7 @@ Gets the absolute angular acceleration of the device in an axis-angle representa
 The angular acceleration as an axis-angle.
 
 ## -remarks
-The value of the property is a vector which indicates the axis of rotation. The magnitude of the vector indicates the rate of rotation counter-clockwise about the axis, looking down the vector towards the origin - that is, according to the right-hand rule. For example, in a coordinate system where +Y points upward, turning to the right will produce an axis-angle with a direction close to (0, -1, 0) and a magnitude proportional to the rate of rotation. Note that this is the opposite convention from the angular velocity axis angle, which uses the left-hand rule. You can change the convention of either vector to make the values consistent by negating all three components.
+The value of the property is a vector which indicates the axis of rotation. The magnitude of the vector indicates the rate of rotation clockwise about the axis, looking from the origin in the direction of the vector - that is, according to the right-hand rule. For example, in a coordinate system where +Y points upward, turning to the right will produce an axis-angle with a direction close to (0, -1, 0) and a magnitude proportional to the rate of rotation. Note that this is the opposite convention from the angular velocity axis angle, which uses the left-hand rule. You can change the convention of either vector to make the values consistent by negating all three components.
 
 ## -see-also
 

--- a/windows.perception.spatial/spatiallocation_absoluteangularaccelerationaxisangle.md
+++ b/windows.perception.spatial/spatiallocation_absoluteangularaccelerationaxisangle.md
@@ -17,7 +17,7 @@ Gets the absolute angular acceleration of the device in an axis-angle representa
 The angular acceleration as an axis-angle.
 
 ## -remarks
-The value of the property is a vector which indicates the axis of rotation. The magnitude of the vector indicates the rate of rotation clockwise about the axis, looking down the vector towards the origin - that is, according to the left-hand rule. For example, in a coordinate system where +Y points upward, turning to the right will produce an axis-angle with a direction close to (0, 1, 0) and a magnitude proportional to the rate of rotation.
+The value of the property is a vector which indicates the axis of rotation. The magnitude of the vector indicates the rate of rotation counter-clockwise about the axis, looking down the vector towards the origin - that is, according to the right-hand rule. For example, in a coordinate system where +Y points upward, turning to the right will produce an axis-angle with a direction close to (0, 1, 0) and a magnitude proportional to the rate of rotation. Note that this is the opposite convention from the angular velocity axis angle, which uses the left-hand rule. You can change the convention of the vector to make the values consistent by negating all three components.
 
 ## -see-also
 

--- a/windows.perception.spatial/spatiallocation_absoluteangularaccelerationaxisangle.md
+++ b/windows.perception.spatial/spatiallocation_absoluteangularaccelerationaxisangle.md
@@ -17,7 +17,7 @@ Gets the absolute angular acceleration of the device in an axis-angle representa
 The angular acceleration as an axis-angle.
 
 ## -remarks
-The value of the property is a vector which indicates the axis of rotation. The magnitude of the vector indicates the rate of rotation counter-clockwise about the axis. For example, in a coordinate system where +Y points upward, turning to the right will produce an  axis-angle with a direction close to (0, 1, 0) and a magnitude proportional to the rate of rotation.
+The value of the property is a vector which indicates the axis of rotation. The magnitude of the vector indicates the rate of rotation clockwise about the axis, looking down the vector towards the origin - that is, according to the left-hand rule. For example, in a coordinate system where +Y points upward, turning to the right will produce an axis-angle with a direction close to (0, 1, 0) and a magnitude proportional to the rate of rotation.
 
 ## -see-also
 

--- a/windows.perception.spatial/spatiallocation_absoluteangularaccelerationaxisangle.md
+++ b/windows.perception.spatial/spatiallocation_absoluteangularaccelerationaxisangle.md
@@ -17,6 +17,7 @@ Gets the absolute angular acceleration of the device in an axis-angle representa
 The angular acceleration as an axis-angle.
 
 ## -remarks
+The value of the property is a vector which indicates the axis of rotation. The magnitude of the vector indicates the rate of rotation counter-clockwise about the axis. For example, in a coordinate system where +Y points upward, turning to the right will produce an  axis-angle with a direction close to (0, 1, 0) and a magnitude proportional to the rate of rotation.
 
 ## -see-also
 

--- a/windows.perception.spatial/spatiallocation_absoluteangularaccelerationaxisangle.md
+++ b/windows.perception.spatial/spatiallocation_absoluteangularaccelerationaxisangle.md
@@ -17,7 +17,7 @@ Gets the absolute angular acceleration of the device in an axis-angle representa
 The angular acceleration as an axis-angle.
 
 ## -remarks
-The value of the property is a vector which indicates the axis of rotation. The magnitude of the vector indicates the rate of rotation counter-clockwise about the axis, looking down the vector towards the origin - that is, according to the right-hand rule. For example, in a coordinate system where +Y points upward, turning to the right will produce an axis-angle with a direction close to (0, 1, 0) and a magnitude proportional to the rate of rotation. Note that this is the opposite convention from the angular velocity axis angle, which uses the left-hand rule. You can change the convention of the vector to make the values consistent by negating all three components.
+The value of the property is a vector which indicates the axis of rotation. The magnitude of the vector indicates the rate of rotation counter-clockwise about the axis, looking down the vector towards the origin - that is, according to the right-hand rule. For example, in a coordinate system where +Y points upward, turning to the right will produce an axis-angle with a direction close to (0, -1, 0) and a magnitude proportional to the rate of rotation. Note that this is the opposite convention from the angular velocity axis angle, which uses the left-hand rule. You can change the convention of either vector to make the values consistent by negating all three components.
 
 ## -see-also
 

--- a/windows.perception.spatial/spatiallocation_absoluteangularaccelerationaxisangle.md
+++ b/windows.perception.spatial/spatiallocation_absoluteangularaccelerationaxisangle.md
@@ -17,7 +17,7 @@ Gets the absolute angular acceleration of the device in an axis-angle representa
 The angular acceleration as an axis-angle.
 
 ## -remarks
-The value of the property is a vector which indicates the axis of rotation. The magnitude of the vector indicates the rate of rotation clockwise about the axis, looking from the origin in the direction of the vector - that is, according to the right-hand rule. For example, in a coordinate system where +Y points upward, turning to the right will produce an axis-angle with a direction close to (0, -1, 0) and a magnitude proportional to the rate of rotation. Note that this is the opposite convention from the angular velocity axis angle, which uses the left-hand rule. You can change the convention of either vector to make the values consistent by negating all three components.
+The value of the property is a vector which indicates the axis of rotation. The magnitude of the vector indicates the rate of rotation counter-clockwise about the axis, looking back along the vector towards the origin - that is, according to the right-hand rule. For example, in a coordinate system where +Y points upward, turning to the right will produce an axis-angle with a direction close to (0, -1, 0) and a magnitude proportional to the rate of rotation. Note that this is the opposite convention from the angular velocity axis angle, which uses the left-hand rule. You can change the convention of either vector to make the values consistent by negating all three components.
 
 ## -see-also
 

--- a/windows.perception.spatial/spatiallocation_absoluteangularvelocityaxisangle.md
+++ b/windows.perception.spatial/spatiallocation_absoluteangularvelocityaxisangle.md
@@ -17,7 +17,7 @@ Gets the absolute angular velocity of the device in an axis-angle representation
 The angular velocity as an axis-angle.
 
 ## -remarks
-The value of the property is a vector which indicates the axis of rotation. The length of the vector indicates the rate of rotation counter-clockwise about the axis. For example, in a coordinate system where +Y points upward, turning to the right will produce an angular velocity axis-angle with a direction close to (0, 1, 0) and a magnitude proportional to the rate of rotation.
+The value of the property is a vector which indicates the axis of rotation. The magnitude of the vector indicates the rate of rotation counter-clockwise about the axis. For example, in a coordinate system where +Y points upward, turning to the right will produce an axis-angle with a direction close to (0, 1, 0) and a magnitude proportional to the rate of rotation.
 
 ## -see-also
 

--- a/windows.perception.spatial/spatiallocation_absoluteangularvelocityaxisangle.md
+++ b/windows.perception.spatial/spatiallocation_absoluteangularvelocityaxisangle.md
@@ -17,6 +17,7 @@ Gets the absolute angular velocity of the device in an axis-angle representation
 The angular velocity as an axis-angle.
 
 ## -remarks
+The value of the property is a vector which indicates the axis of rotation. The length of the vector indicates the rate of rotation counter-clockwise about the axis. For example, in a coordinate system where +Y points upward, turning to the right will produce an angular velocity axis-angle with a direction close to (0, 1, 0) and a magnitude proportional to the rate of rotation.
 
 ## -see-also
 

--- a/windows.perception.spatial/spatiallocation_absoluteangularvelocityaxisangle.md
+++ b/windows.perception.spatial/spatiallocation_absoluteangularvelocityaxisangle.md
@@ -17,7 +17,7 @@ Gets the absolute angular velocity of the device in an axis-angle representation
 The angular velocity as an axis-angle.
 
 ## -remarks
-The value of the property is a vector which indicates the axis of rotation. The magnitude of the vector indicates the rate of rotation clockwise about the axis, looking down the vector towards the origin - that is, according to the left-hand rule. For example, in a coordinate system where +Y points upward, turning to the right will produce an axis-angle with a direction close to (0, 1, 0) and a magnitude proportional to the rate of rotation.
+The value of the property is a vector which indicates the axis of rotation. The magnitude of the vector indicates the rate of rotation clockwise about the axis, looking down the vector towards the origin - that is, according to the left-hand rule. For example, in a coordinate system where +Y points upward, turning to the right will produce an axis-angle with a direction close to (0, 1, 0) and a magnitude proportional to the rate of rotation. Note that this is the opposite convention from the angular acceleration axis angle, which uses the right-hand rule. You can change the convention of either vector to make the values consistent by negating all three components.
 
 ## -see-also
 

--- a/windows.perception.spatial/spatiallocation_absoluteangularvelocityaxisangle.md
+++ b/windows.perception.spatial/spatiallocation_absoluteangularvelocityaxisangle.md
@@ -17,7 +17,7 @@ Gets the absolute angular velocity of the device in an axis-angle representation
 The angular velocity as an axis-angle.
 
 ## -remarks
-The value of the property is a vector which indicates the axis of rotation. The magnitude of the vector indicates the rate of rotation counter-clockwise about the axis. For example, in a coordinate system where +Y points upward, turning to the right will produce an axis-angle with a direction close to (0, 1, 0) and a magnitude proportional to the rate of rotation.
+The value of the property is a vector which indicates the axis of rotation. The magnitude of the vector indicates the rate of rotation clockwise about the axis, looking down the vector towards the origin - that is, according to the left-hand rule. For example, in a coordinate system where +Y points upward, turning to the right will produce an axis-angle with a direction close to (0, 1, 0) and a magnitude proportional to the rate of rotation.
 
 ## -see-also
 

--- a/windows.perception.spatial/spatiallocation_absoluteangularvelocityaxisangle.md
+++ b/windows.perception.spatial/spatiallocation_absoluteangularvelocityaxisangle.md
@@ -17,7 +17,7 @@ Gets the absolute angular velocity of the device in an axis-angle representation
 The angular velocity as an axis-angle.
 
 ## -remarks
-The value of the property is a vector which indicates the axis of rotation. The magnitude of the vector indicates the rate of rotation clockwise about the axis, looking down the vector towards the origin - that is, according to the left-hand rule. For example, in a coordinate system where +Y points upward, turning to the right will produce an axis-angle with a direction close to (0, 1, 0) and a magnitude proportional to the rate of rotation. Note that this is the opposite convention from the angular acceleration axis angle, which uses the right-hand rule. You can change the convention of either vector to make the values consistent by negating all three components.
+The value of the property is a vector which indicates the axis of rotation. The magnitude of the vector indicates the rate of rotation clockwise about the axis, looking back along the vector towards the origin - that is, according to the left-hand rule. For example, in a coordinate system where +Y points upward, turning to the right will produce an axis-angle with a direction close to (0, 1, 0) and a magnitude proportional to the rate of rotation. Note that this is the opposite convention from the angular acceleration axis angle, which uses the right-hand rule. You can change the convention of either vector to make the values consistent by negating all three components.
 
 ## -see-also
 

--- a/windows.perception.spatial/spatiallocation_absolutelinearacceleration.md
+++ b/windows.perception.spatial/spatiallocation_absolutelinearacceleration.md
@@ -17,6 +17,9 @@ Gets the absolute acceleration vector of the device in units of meters per secon
 The acceleration.
 
 ## -remarks
+<div class="alert"><b>Important</b>
+  <p class="note">The acceleration values reported by this API are inverted; to get the actual acceleration, negate all three components. Velocity values are reported correctly and do not need to be negated.
+</div>
 
 ## -examples
 


### PR DESCRIPTION
The SpatialLocation API provides angular velocity and acceleration as axis-angle values, but the documentation does not explain how to interpret these values. These changes add details to explain how the values should be interpreted. It also clarifies some quirks in the implementation which are essential to understand in order to use the APIs.