### PR TITLE
Corrected visible/hidden mesh to reference "NDC space"

### DIFF
--- a/windows.graphics.holographic/holographiccameraviewportparameters_hiddenareamesh.md
+++ b/windows.graphics.holographic/holographiccameraviewportparameters_hiddenareamesh.md
@@ -10,7 +10,7 @@ public Vector2[] HiddenAreaMesh { get; }
 # Windows.Graphics.Holographic.HolographicCameraViewportParameters.HiddenAreaMesh
 
 ## -description
-Gets screen-space vertices that define the viewport area the user cannot see, given the headset's lens geometry.
+Gets vertices in NDC space that define the viewport area the user cannot see, given the headset's lens geometry.
 
 ## -property-value
 The hidden area mesh vertices.

--- a/windows.graphics.holographic/holographiccameraviewportparameters_visibleareamesh.md
+++ b/windows.graphics.holographic/holographiccameraviewportparameters_visibleareamesh.md
@@ -10,7 +10,7 @@ public Vector2[] VisibleAreaMesh { get; }
 # Windows.Graphics.Holographic.HolographicCameraViewportParameters.VisibleAreaMesh
 
 ## -description
-Gets screen-space vertices that define the viewport area the user can see, given the headset's lens geometry.
+Gets vertices in NDC space that define the viewport area the user can see, given the headset's lens geometry.
 
 ## -property-value
 The visible area mesh vertices.


### PR DESCRIPTION
This fixes an error in today's docs for `HiddenAreaMesh` and `VisibleAreaMesh`.