### PR TITLE
Change time code param value limit

### DIFF
--- a/windows.devices.midi/miditimecodemessage_miditimecodemessage_969710101.md
+++ b/windows.devices.midi/miditimecodemessage_miditimecodemessage_969710101.md
@@ -17,7 +17,7 @@ Creates a new [MidiTimeCodeMessage](miditimecodemessage.md) object.
 The frame type from 0-7.
 
 ### -param values
-The time code from 0-32.
+The time code from 0-15.
 
 ## -remarks
 If any values passed into the constructor fo not adhere to the specified requirements, an invalid argument exception will be thrown.

--- a/windows.devices.midi/miditimecodemessage_values.md
+++ b/windows.devices.midi/miditimecodemessage_values.md
@@ -10,10 +10,10 @@ public byte Values { get; }
 # Windows.Devices.Midi.MidiTimeCodeMessage.Values
 
 ## -description
-Gets the time code value from 0-32.
+Gets the time code value from 0-15.
 
 ## -property-value
-The time code value from 0-32.
+The time code value from 0-15.
 
 ## -remarks
 


### PR DESCRIPTION
The docs mention 32 as time code limit, but according to my tests, the API throws `ArgumentException` for any value above 15 (which also matches the logic mentioned at http://www.4front-tech.com/pguide/midi/midi9.html. It seems then, that the documentation should be changed to limit this parameter to 15.