### PR TITLE
Connect WebAuthenticationCoreManager and IWebAuthenticationCoreManagerInterop

### DIFF
--- a/windows.security.authentication.web.core/webauthenticationcoremanager_requesttokenasync_1777535178.md
+++ b/windows.security.authentication.web.core/webauthenticationcoremanager_requesttokenasync_1777535178.md
@@ -27,7 +27,10 @@ For an equivalent of this method for desktop apps, see
 ## -examples
 
 ## -see-also
-[Web account management code sample](https://github.com/Microsoft/Windows-universal-samples/tree/master/Samples/WebAccountManagement),
-[RequestTokenAsync(WebTokenRequest, WebAccount)](webauthenticationcoremanager_requesttokenasync_695504446.md),
-[IWebAuthenticationCoreManagerInterop::RequestTokenForWindowAsync](/windows/win32/api/webauthenticationcoremanagerinterop/nf-webauthenticationcoremanagerinterop-iwebauthenticationcoremanagerinterop-requesttokenforwindowasync), 
-[IWebAuthenticationCoreManagerInterop](/windows/win32/api/webauthenticationcoremanagerinterop/nf-webauthenticationcoremanagerinterop-iwebauthenticationcoremanagerinterop) interface
+[Web account management code sample](https://github.com/Microsoft/Windows-universal-samples/tree/master/Samples/WebAccountManagement)
+
+[RequestTokenAsync(WebTokenRequest, WebAccount)](webauthenticationcoremanager_requesttokenasync_695504446.md)
+
+[IWebAuthenticationCoreManagerInterop::RequestTokenForWindowAsync](/windows/win32/api/webauthenticationcoremanagerinterop/nf-webauthenticationcoremanagerinterop-iwebauthenticationcoremanagerinterop-requesttokenforwindowasync)
+
+[IWebAuthenticationCoreManagerInterop interface](/windows/win32/api/webauthenticationcoremanagerinterop/nf-webauthenticationcoremanagerinterop-iwebauthenticationcoremanagerinterop)

--- a/windows.security.authentication.web.core/webauthenticationcoremanager_requesttokenasync_1777535178.md
+++ b/windows.security.authentication.web.core/webauthenticationcoremanager_requesttokenasync_1777535178.md
@@ -27,4 +27,7 @@ For an equivalent of this method for desktop apps, see
 ## -examples
 
 ## -see-also
-[Web account management code sample](https://github.com/Microsoft/Windows-universal-samples/tree/master/Samples/WebAccountManagement), [RequestTokenAsync(WebTokenRequest, WebAccount)](webauthenticationcoremanager_requesttokenasync_695504446.md), [IWebAuthenticationCoreManagerInterop::RequestTokenForWindowAsync](/windows/win32/api/webauthenticationcoremanagerinterop/nf-webauthenticationcoremanagerinterop-iwebauthenticationcoremanagerinterop-requesttokenforwindowasync), [IWebAuthenticationCoreManagerInterop](/windows/win32/api/webauthenticationcoremanagerinterop/nf-webauthenticationcoremanagerinterop-iwebauthenticationcoremanagerinterop) interface
+[Web account management code sample](https://github.com/Microsoft/Windows-universal-samples/tree/master/Samples/WebAccountManagement),
+[RequestTokenAsync(WebTokenRequest, WebAccount)](webauthenticationcoremanager_requesttokenasync_695504446.md),
+[IWebAuthenticationCoreManagerInterop::RequestTokenForWindowAsync](/windows/win32/api/webauthenticationcoremanagerinterop/nf-webauthenticationcoremanagerinterop-iwebauthenticationcoremanagerinterop-requesttokenforwindowasync), 
+[IWebAuthenticationCoreManagerInterop](/windows/win32/api/webauthenticationcoremanagerinterop/nf-webauthenticationcoremanagerinterop-iwebauthenticationcoremanagerinterop) interface

--- a/windows.security.authentication.web.core/webauthenticationcoremanager_requesttokenasync_1777535178.md
+++ b/windows.security.authentication.web.core/webauthenticationcoremanager_requesttokenasync_1777535178.md
@@ -20,9 +20,11 @@ The web token request.
 An asynchronous request operation. On successful completion, contains a [WebTokenRequestResult](webtokenrequestresult.md) object representing the result of the web token request.
 
 ## -remarks
-This method cannot be called from background threads.
+This method cannot be called from desktop apps or from background threads of UWP apps.
+For an equivalent of this method for desktop apps, see
+[IWebAuthenticationCoreManagerInterop::RequestTokenForWindowAsync](/windows/win32/api/webauthenticationcoremanagerinterop/nf-webauthenticationcoremanagerinterop-iwebauthenticationcoremanagerinterop-requesttokenforwindowasync).
 
 ## -examples
 
 ## -see-also
-[Web account management code sample](https://github.com/Microsoft/Windows-universal-samples/tree/master/Samples/WebAccountManagement), [RequestTokenAsync(WebTokenRequest, WebAccount)](webauthenticationcoremanager_requesttokenasync_695504446.md)
+[Web account management code sample](https://github.com/Microsoft/Windows-universal-samples/tree/master/Samples/WebAccountManagement), [RequestTokenAsync(WebTokenRequest, WebAccount)](webauthenticationcoremanager_requesttokenasync_695504446.md), [IWebAuthenticationCoreManagerInterop::RequestTokenForWindowAsync](/windows/win32/api/webauthenticationcoremanagerinterop/nf-webauthenticationcoremanagerinterop-iwebauthenticationcoremanagerinterop-requesttokenforwindowasync), [IWebAuthenticationCoreManagerInterop](/windows/win32/api/webauthenticationcoremanagerinterop/nf-webauthenticationcoremanagerinterop-iwebauthenticationcoremanagerinterop) interface

--- a/windows.security.authentication.web.core/webauthenticationcoremanager_requesttokenasync_695504446.md
+++ b/windows.security.authentication.web.core/webauthenticationcoremanager_requesttokenasync_695504446.md
@@ -23,9 +23,14 @@ The web account for the request.
 An asynchronous request operation. On successful completion, contains a [WebTokenRequestResult](webtokenrequestresult.md) object representing the result of the web token request.
 
 ## -remarks
-This method cannot be called from background threads.
+This method cannot be called from desktop apps or from background threads of UWP apps.
+For an equivalent of this method for desktop apps, see
+[IWebAuthenticationCoreManagerInterop::RequestTokenWithWebAccountForWindowAsync](/windows/win32/api/webauthenticationcoremanagerinterop/nf-webauthenticationcoremanagerinterop-iwebauthenticationcoremanagerinterop-requesttokenwithwebaccountforwindowasync).
 
 ## -examples
 
 ## -see-also
-[Web account management code sample](https://github.com/Microsoft/Windows-universal-samples/tree/master/Samples/WebAccountManagement), [RequestTokenAsync(WebTokenRequest)](webauthenticationcoremanager_requesttokenasync_1777535178.md)
+[Web account management code sample](https://github.com/Microsoft/Windows-universal-samples/tree/master/Samples/WebAccountManagement),
+[RequestTokenAsync(WebTokenRequest)](webauthenticationcoremanager_requesttokenasync_1777535178.md),
+[IWebAuthenticationCoreManagerInterop::RequestTokenWithWebAccountForWindowAsync](/windows/win32/api/webauthenticationcoremanagerinterop/nf-webauthenticationcoremanagerinterop-iwebauthenticationcoremanagerinterop-requesttokenwithwebaccountforwindowasync),
+[IWebAuthenticationCoreManagerInterop](/windows/win32/api/webauthenticationcoremanagerinterop/nf-webauthenticationcoremanagerinterop-iwebauthenticationcoremanagerinterop) interface

--- a/windows.security.authentication.web.core/webauthenticationcoremanager_requesttokenasync_695504446.md
+++ b/windows.security.authentication.web.core/webauthenticationcoremanager_requesttokenasync_695504446.md
@@ -30,7 +30,10 @@ For an equivalent of this method for desktop apps, see
 ## -examples
 
 ## -see-also
-[Web account management code sample](https://github.com/Microsoft/Windows-universal-samples/tree/master/Samples/WebAccountManagement),
-[RequestTokenAsync(WebTokenRequest)](webauthenticationcoremanager_requesttokenasync_1777535178.md),
-[IWebAuthenticationCoreManagerInterop::RequestTokenWithWebAccountForWindowAsync](/windows/win32/api/webauthenticationcoremanagerinterop/nf-webauthenticationcoremanagerinterop-iwebauthenticationcoremanagerinterop-requesttokenwithwebaccountforwindowasync),
-[IWebAuthenticationCoreManagerInterop](/windows/win32/api/webauthenticationcoremanagerinterop/nf-webauthenticationcoremanagerinterop-iwebauthenticationcoremanagerinterop) interface
+[Web account management code sample](https://github.com/Microsoft/Windows-universal-samples/tree/master/Samples/WebAccountManagement)
+
+[RequestTokenAsync(WebTokenRequest)](webauthenticationcoremanager_requesttokenasync_1777535178.md)
+
+[IWebAuthenticationCoreManagerInterop::RequestTokenWithWebAccountForWindowAsync](/windows/win32/api/webauthenticationcoremanagerinterop/nf-webauthenticationcoremanagerinterop-iwebauthenticationcoremanagerinterop-requesttokenwithwebaccountforwindowasync)
+
+[IWebAuthenticationCoreManagerInterop interface](/windows/win32/api/webauthenticationcoremanagerinterop/nf-webauthenticationcoremanagerinterop-iwebauthenticationcoremanagerinterop)


### PR DESCRIPTION
Certain methods of [WebAuthenticationCoreManager](https://docs.microsoft.com/en-us/uwp/api/windows.security.authentication.web.core.webauthenticationcoremanager) aren't intended to be called from desktop apps. Instead, WebAuthenticationCoreManager provides substitute methods that can be called from desktop apps. To give access to these substitute methods, WebAuthenticationCoreManager's activation factory also implements the [IWebAuthenticationCoreManagerInterop](https://docs.microsoft.com/en-us/windows/win32/api/webauthenticationcoremanagerinterop/nn-webauthenticationcoremanagerinterop-iwebauthenticationcoremanagerinterop) interface.

This change helps connect the two interfaces together by linking from the desktop-prohibited methods of WebAuthenticationCoreManager to the desktop-ready equivalents in IWebAuthenticationCoreManagerInterop.

Intended to pair with https://github.com/MicrosoftDocs/sdk-api/pull/254