### PR TITLE
Added information about MediaCaptureInitializationSettings properties

### DIFF
--- a/windows.media.capture/mediacaptureinitializationsettings.md
+++ b/windows.media.capture/mediacaptureinitializationsettings.md
@@ -27,7 +27,7 @@ For how-to guidance on initializing and shutting down the **MediaCapture** objec
 | 1703 | 15063 | AlwaysPlaySystemShutterSound |
 
 > [!NOTE]
-> When **MediaCaptureSharingMode::SharedReadOnly** is used, some of the MediaCaptureInitializationSettings properties could not be configured. See [SharingMode](mediacaptureinitializationsettings_sharingmode.md) for details.
+> When **MediaCaptureSharingMode::SharedReadOnly** is used, some of the MediaCaptureInitializationSettings properties can't be configured. See [SharingMode](mediacaptureinitializationsettings_sharingmode.md) for details.
 
 ## -examples
 

--- a/windows.media.capture/mediacaptureinitializationsettings.md
+++ b/windows.media.capture/mediacaptureinitializationsettings.md
@@ -26,6 +26,9 @@ For how-to guidance on initializing and shutting down the **MediaCapture** objec
 | 1607 | 14393 | SourceGroup |
 | 1703 | 15063 | AlwaysPlaySystemShutterSound |
 
+> [!NOTE]
+> When **MediaCaptureSharingMode::SharedReadOnly** is used, some of the MediaCaptureInitializationSettings properties could not be configured. See [SharingMode](mediacaptureinitializationsettings_sharingmode.md) for details.
+
 ## -examples
 
 The following example initializes the **MediaCaptureInitializationSettings**. Call [InitializeAsync](mediacapture_initializeasync_837464435.md) with these settings to initialize a [MediaCapture](mediacapture.md) object.

--- a/windows.media.capture/mediacaptureinitializationsettings_sharingmode.md
+++ b/windows.media.capture/mediacaptureinitializationsettings_sharingmode.md
@@ -18,7 +18,7 @@ An object that specifies the sharing mode for the [MediaCapture](mediacapture.md
 ## -remarks
 Multiple apps can simultaneously acquire frames from the same [MediaFrameSource](../windows.media.capture.frames/mediaframesource.md), but only a single app can acquire exclusive control of and modify the settings for the frame source. Set **SharingMode** to [ExclusiveControl](mediacapturesharingmode.md) if you need to adjust the configuration of any of the frame sources included the requested [SourceGroup](mediacaptureinitializationsettings_sourcegroup.md). However, this means that the call to [InitializeAsync](mediacapture_initializeasync_315323248.md) will fail if another app already has exclusive control of one of the frame sources in the group. If you only need to acquire frames without modifying the configuration, set **SharingMode** to [SharedReadOnly](mediacapturesharingmode.md).
 
-When the **SharingMode** is set to [SharedReadOnly](mediacapturesharingmode.md), some of the MediaCaptureInitializationSettings properties may not be abled to be configured. See below table for details.
+When the **SharingMode** is set to [SharedReadOnly](mediacapturesharingmode.md), some of the MediaCaptureInitializationSettings properties could not be configured. See below table for details.
 
 | **Properties** | **Can be configured in Sharing Mode** |
 |----------------|---------------------------------------|

--- a/windows.media.capture/mediacaptureinitializationsettings_sharingmode.md
+++ b/windows.media.capture/mediacaptureinitializationsettings_sharingmode.md
@@ -18,7 +18,7 @@ An object that specifies the sharing mode for the [MediaCapture](mediacapture.md
 ## -remarks
 Multiple apps can simultaneously acquire frames from the same [MediaFrameSource](../windows.media.capture.frames/mediaframesource.md), but only a single app can acquire exclusive control of and modify the settings for the frame source. Set **SharingMode** to [ExclusiveControl](mediacapturesharingmode.md) if you need to adjust the configuration of any of the frame sources included the requested [SourceGroup](mediacaptureinitializationsettings_sourcegroup.md). However, this means that the call to [InitializeAsync](mediacapture_initializeasync_315323248.md) will fail if another app already has exclusive control of one of the frame sources in the group. If you only need to acquire frames without modifying the configuration, set **SharingMode** to [SharedReadOnly](mediacapturesharingmode.md).
 
-When the **SharingMode** is set to [SharedReadOnly](mediacapturesharingmode.md), some of the MediaCaptureInitializationSettings properties could not be configured. See below table for details.
+When the **SharingMode** is set to [SharedReadOnly](mediacapturesharingmode.md), some of the MediaCaptureInitializationSettings properties can't be configured. See below table for details.
 
 | **Properties** | **Can be configured in Sharing Mode** |
 |----------------|---------------------------------------|

--- a/windows.media.capture/mediacaptureinitializationsettings_sharingmode.md
+++ b/windows.media.capture/mediacaptureinitializationsettings_sharingmode.md
@@ -18,6 +18,28 @@ An object that specifies the sharing mode for the [MediaCapture](mediacapture.md
 ## -remarks
 Multiple apps can simultaneously acquire frames from the same [MediaFrameSource](../windows.media.capture.frames/mediaframesource.md), but only a single app can acquire exclusive control of and modify the settings for the frame source. Set **SharingMode** to [ExclusiveControl](mediacapturesharingmode.md) if you need to adjust the configuration of any of the frame sources included the requested [SourceGroup](mediacaptureinitializationsettings_sourcegroup.md). However, this means that the call to [InitializeAsync](mediacapture_initializeasync_315323248.md) will fail if another app already has exclusive control of one of the frame sources in the group. If you only need to acquire frames without modifying the configuration, set **SharingMode** to [SharedReadOnly](mediacapturesharingmode.md).
 
+When the **SharingMode** is set to [SharedReadOnly](mediacapturesharingmode.md), some of the MediaCaptureInitializationSettings properties may not be abled to be configured. See below table for details.
+
+| **Properties** | **Can be configured in Sharing Mode** |
+|----------------|---------------------------------------|
+| [AlwaysPlaySystemShutterSound](mediacaptureinitializationsettings_alwaysplaysystemshuttersound.md) | Yes |
+| [AudioDeviceId](mediacaptureinitializationsettings_audiodeviceid.md) | Yes |
+| [AudioProcessing](mediacaptureinitializationsettings_audioprocessing.md) | Yes |
+| [AudioSource](mediacaptureinitializationsettings_audiosource.md) | N/A |
+| [DeviceUri](mediacaptureinitializationsettings_deviceuri.md) | Yes |
+| [DeviceUriPasswordCredential](mediacaptureinitializationsettings_deviceuripasswordcredential.md) | Yes |
+| [MediaCategory](mediacaptureinitializationsettings_mediacategory.md) | Yes |
+| [MemoryPreference](mediacaptureinitializationsettings_memorypreference.md) | Yes |
+| [PhotoCaptureSource](mediacaptureinitializationsettings_photocapturesource.md) | N/A |
+| [PhotoMediaDescription](mediacaptureinitializationsettings_photomediadescription.md) | No |
+| [PreviewMediaDescription](mediacaptureinitializationsettings_previewmediadescription.md) | No |
+| [RecordMediaDescription](mediacaptureinitializationsettings_recordmediadescription.md) | No |
+| [SourceGroup](mediacaptureinitializationsettings_sourcegroup.md) | Yes |
+| [StreamingCaptureMode](mediacaptureinitializationsettings_streamingcapturemode.md) | Yes |
+| [VideoDeviceId](mediacaptureinitializationsettings_videodeviceid.md) | Yes |
+| [VideoProfile](mediacaptureinitializationsettings_videoprofile.md) | No |
+| [VideoSource](mediacaptureinitializationsettings_videosource.md) | Yes |
+
 ## -examples
 
 ## -see-also


### PR DESCRIPTION
Added information about what MediaCaptureInitializationSettings properties can be or cannot be configured when ShareMode is set. @kasumman 