### PR TITLE
Bias-free Communication

### DIFF
--- a/windows.devices.spi/spidevice_transferfullduplex_1952292325.md
+++ b/windows.devices.spi/spidevice_transferfullduplex_1952292325.md
@@ -10,7 +10,7 @@ public void TransferFullDuplex(System.Byte[] writeBuffer, System.Byte[] readBuff
 # Windows.Devices.Spi.SpiDevice.TransferFullDuplex
 
 ## -description
-Transfer data using a full duplex communication system. Full duplex allows both the master and the slave to communicate simultaneously.
+Transfer data using a full duplex communication system. Full duplex allows both the master and the subordinate to communicate simultaneously.
 
 ## -parameters
 ### -param writeBuffer


### PR DESCRIPTION
Microsoft supports a diverse and inclusionary environment.  Within this document, there is a reference to the word 'slave.' Microsoft's [Style Guide for Bias-Free Communications](https://github.com/MicrosoftDocs/microsoft-style-guide/blob/master/styleguide/bias-free-communication.md) recognizes this as an exclusionary word.  The change I made edits the word 'slave' to 'subordinate' to be in line with the Style Guide.