### PR TITLE
Add info about the capability

### DIFF
--- a/windows.storage/knownfolders_documentslibrary.md
+++ b/windows.storage/knownfolders_documentslibrary.md
@@ -21,14 +21,14 @@ The Documents library.
 
 If your app has to create and update files that only your app uses, consider using the app's [LocalCache](applicationdata_localcachefolder.md) folder. For more information on which folders you should use for your app's data, see [ApplicationData](applicationdata.md) class.
 
-Alternatively, let the user select the file location by using a file picker. For more info, see [Open files and folders with a picker](https://docs.microsoft.com/windows/uwp/files/quickstart-using-file-and-folder-pickers).
+Alternatively, let the user select the file location by using a file picker. For more info, see [Open files and folders with a picker](https://docs.microsoft.com/windows/uwp/files/quickstart-using-file-and-folder-pickers) and in particular the [`SuggestedStartLocation` property](https://docs.microsoft.com/en-us/uwp/api/windows.storage.pickers.fileopenpicker.suggestedstartlocation?view=winrt-19041) which can be set to [`DocumentsLibrary`](https://docs.microsoft.com/en-us/uwp/api/windows.storage.pickers.pickerlocationid?view=winrt-19041). If the user selects the Documents Library from within the picker, you **do not** need to use this property nor do you need the **documentsLibrary** capability. 
 
 ### Prerequisites
 
-To access the Documents library, do the following things.
+To access the Documents library *without* using a picker, do the following things.
 
-+ In the app manifest, specify the **Documents Library** capability. This capability is not visible in Manifest Designer. To add the Documents Library capability, open the app manifest in code view and edit the XML directly.
-+ In the app manifest, register at least one File Type Association declaration. This declaration explicitly indicates the file types (extensions) that your app wants to access in the Documents library. The app can only enumerate, create, or change files that have the file types declared in the app manifest. For more info, see [Handle file activation](https://docs.microsoft.com/windows/uwp/launch-resume/handle-file-activation).
++ In the app manifest, specify the **Documents Library** capability. This capability is not visible in Manifest Designer. To add the Documents Library capability, open the app manifest in code view and edit the XML directly. You **do not** need this capability if you use the file pickers.
++ In the app manifest, register at least one File Type Association declaration. This declaration explicitly indicates the file types (extensions) that your app wants to access in the Documents library. The app can only enumerate, create, or change files that have the file types declared in the app manifest. For more info, see [Handle file activation](https://docs.microsoft.com/windows/uwp/launch-resume/handle-file-activation). You **do not** need to add this declaration if you use the file pickers.
 
 
 ### Return value

--- a/windows.storage/knownfolders_documentslibrary.md
+++ b/windows.storage/knownfolders_documentslibrary.md
@@ -21,7 +21,7 @@ The Documents library.
 
 If your app has to create and update files that only your app uses, consider using the app's [LocalCache](applicationdata_localcachefolder.md) folder. For more information on which folders you should use for your app's data, see [ApplicationData](applicationdata.md) class.
 
-Alternatively, let the user select the file location by using a file picker. For more info, see [Open files and folders with a picker](https://docs.microsoft.com/windows/uwp/files/quickstart-using-file-and-folder-pickers) and in particular the [`SuggestedStartLocation` property](https://docs.microsoft.com/en-us/uwp/api/windows.storage.pickers.fileopenpicker.suggestedstartlocation?view=winrt-19041) which can be set to [`DocumentsLibrary`](https://docs.microsoft.com/en-us/uwp/api/windows.storage.pickers.pickerlocationid?view=winrt-19041). If the user selects the Documents Library from within the picker, you **do not** need to use this property nor do you need the **documentsLibrary** capability. 
+Alternatively, let the user select the file location by using a file picker. For more info, see [Open files and folders with a picker](https://docs.microsoft.com/windows/uwp/files/quickstart-using-file-and-folder-pickers) and in particular the [`SuggestedStartLocation` property](https://docs.microsoft.com/uwp/api/windows.storage.pickers.fileopenpicker.suggestedstartlocation?view=winrt-19041) which can be set to [`DocumentsLibrary`](https://docs.microsoft.com/uwp/api/windows.storage.pickers.pickerlocationid?view=winrt-19041). If the user selects the Documents Library from within the picker, you **do not** need to use this property nor do you need the **documentsLibrary** capability. 
 
 ### Prerequisites
 


### PR DESCRIPTION
Added disclaimers about when you don't need the capability - we see customers asking for the `documentsLibrary` capability when they're already using the pickers.