### PR TITLE
Don't recommend using null as first parameter in KnownFolders.GetFolderForUserAsync

### DIFF
--- a/windows.storage/knownfolders_getfolderforuserasync_705109113.md
+++ b/windows.storage/knownfolders_getfolderforuserasync_705109113.md
@@ -14,7 +14,7 @@ Static method that returns a specified known folder for a [User](../windows.syst
 
 ## -parameters
 ### -param user
-The [User](../windows.system/user.md) for which the folder is returned. Use `null` for the current user. In context of this API, current user refers to the user context of the process from where the API call is made.
+The [User](../windows.system/user.md) for which the folder is returned.
 
 ### -param folderId
 The ID of the folder to be returned.
@@ -27,4 +27,8 @@ When this method completes, it returns the requested [StorageFolder](storagefold
 ## -examples
 
 ## -see-also
-[KnownFolderId](knownfolderid.md), [StorageFolder](storagefolder.md)
+[KnownFolderId](knownfolderid.md)
+
+[StorageFolder](storagefolder.md)
+
+[GetFolderAsync](knownfolders_getfolderasync_705109113.md)


### PR DESCRIPTION
To get a known folder for the current user, the best way is to use the (new-in-19041) GetFolderAsync method. GetFolderForUserAsync is intended to continue supporting a _null_ user for compatibility, but I've found some issues using it on newer builds, so the docs should recommend the newer approach.

- Removed suggestion to use _null_ as the first parameter to GetFolderForUserAsync
- Add link to the single-user-aware version of the API in the See also section

cc @smaillet-ms