### PR TITLE
Resolve double redirect.

### DIFF
--- a/windows.ui.xaml.controls/frame.md
+++ b/windows.ui.xaml.controls/frame.md
@@ -234,7 +234,7 @@ Private Sub OnNavigationFailed(sender As Object, e As NavigationFailedEventArgs)
 End Sub
 ```
 
-For a complete sample that uses many of the [Page](page.md) and Frame features together, see [XAML Navigation sample](https://github.com/microsoft/Windows-universal-samples/tree/master/Samples/XamlNavigation).
+For a complete sample that uses many of the [Page](page.md) and Frame features together, see [XAML Controls Gallery](https://github.com/microsoft/Xaml-Controls-Gallery).
 
 ## -see-also
 [Page](page.md), [ContentControl](contentcontrol.md), [INavigate](inavigate.md), [Navigation design basics overview](https://docs.microsoft.com/windows/uwp/design/basics/navigation-basics), [XAML Navigation sample](https://github.com/microsoft/Windows-universal-samples/tree/master/Samples/XamlNavigation)

--- a/windows.ui.xaml.controls/frame.md
+++ b/windows.ui.xaml.controls/frame.md
@@ -234,7 +234,7 @@ Private Sub OnNavigationFailed(sender As Object, e As NavigationFailedEventArgs)
 End Sub
 ```
 
-For a complete sample that uses many of the [Page](page.md) and Frame features together, see [XAML Controls Gallery](https://github.com/microsoft/Xaml-Controls-Gallery).
+For a complete sample that uses many of the [Page](page.md) and Frame features together, see the [XAML Controls Gallery](https://github.com/microsoft/Xaml-Controls-Gallery).
 
 ## -see-also
 [Page](page.md), [ContentControl](contentcontrol.md), [INavigate](inavigate.md), [Navigation design basics overview](https://docs.microsoft.com/windows/uwp/design/basics/navigation-basics), [XAML Navigation sample](https://github.com/microsoft/Windows-universal-samples/tree/master/Samples/XamlNavigation)


### PR DESCRIPTION
The [current link](https://github.com/microsoft/Windows-universal-samples/tree/master/Samples/XamlNavigation) sends you to a page dedicated to redirecting [here](https://github.com/microsoft/Windows-universal-samples/tree/master/Samples/XamlUIBasics), which further redirects you to the [XAML Controls Gallery](https://github.com/Microsoft/Xaml-Controls-Gallery).