### PR TITLE
Adding warning text for known issue in Windows 10, version 2004 and below

### DIFF
--- a/windows.ui.composition/compositionrectanglegeometry.md
+++ b/windows.ui.composition/compositionrectanglegeometry.md
@@ -11,6 +11,9 @@ public class CompositionRectangleGeometry : CompositionGeometry, CompositionGeom
 
 ## -description
 
+> [!WARNING]
+> This API is not currently supported. Do not call this API in your code.
+
 Represents a rectangle shape of the specified size.
 
 ## -remarks

--- a/windows.ui.composition/compositionrectanglegeometry.md
+++ b/windows.ui.composition/compositionrectanglegeometry.md
@@ -12,7 +12,7 @@ public class CompositionRectangleGeometry : CompositionGeometry, CompositionGeom
 ## -description
 
 > [!WARNING]
-> This API is not currently supported. Do not call this API in your code.
+> This API contains a known issue in Windows 10, versions 2004 and below. Do not use this API in your code.
 
 Represents a rectangle shape of the specified size.
 


### PR DESCRIPTION
Per dev owner, this API should not be used in Windows 10, version 2004 (current version as of time of writing) and below.