### PR TITLE
Update backgroundtaskbuilder_isnetworkrequested.md

### DIFF
--- a/windows.applicationmodel.background/backgroundtaskbuilder_isnetworkrequested.md
+++ b/windows.applicationmodel.background/backgroundtaskbuilder_isnetworkrequested.md
@@ -18,6 +18,8 @@ Indicates whether to keep the network up while running the background task.
 ## -remarks
 This property is applicable to desktops computers on which disconnected standby is implemented. Setting this property to `true` keeps the network up while the background task is executing, even if the device has entered Connected Standby mode.
 
+The WinMain application components in Desktop Bridge applications may not execute code in disconnected standby or connected standby. WinMain components using [COM background tasks](https://docs.microsoft.com/windows/uwp/launch-resume/create-and-register-a-winmain-background-task) will not observe any behavioral differences when setting this flag.
+
 ## -examples
 
 ## -see-also


### PR DESCRIPTION
This change clarifies in the remarks that the WinMain component (i.e., the Win32, non-UWP-sidecar component) in Desktop Bridge applications do not execute code in standby today. Thereby, using the IsNetworkRequested flag in the BackgroundTaskBuilder has no net effect on the application's behavior when creating WinMain COM background tasks.