### PR TITLE
Update vpnmanagementagent_updateprofilefromobjectasync_1348691922.md

### DIFF
--- a/windows.networking.vpn/vpnmanagementagent_updateprofilefromobjectasync_1348691922.md
+++ b/windows.networking.vpn/vpnmanagementagent_updateprofilefromobjectasync_1348691922.md
@@ -10,16 +10,21 @@ public Windows.Foundation.IAsyncOperation<Windows.Networking.Vpn.VpnManagementEr
 # Windows.Networking.Vpn.VpnManagementAgent.UpdateProfileFromObjectAsync
 
 ## -description
-Updates a VPN profile based on an input object.
+
+Updates a virtual private network (VPN) profile based on an input object.
 
 ## -remarks
-A UWP VPN app can only update per-app profiles; it cannot update any other VPN profile. Apps that attempt to modify a per-user profile may instead create or modify a per-app profile; the new per-app profile will have the same name as the per-user profile.
+
+A Universal Windows Platform (UWP) VPN app can update only per-app profiles; it can't update any other VPN profile. An app that attempts to modify a per-user profile can instead create or modify a per-app profile; the new per-app profile will have the same name as the per-user profile.
 
 ## -parameters
+
 ### -param profile
-A **VpnProfile** object.
+
+A VPN profile object&mdash;an object that implements the [IVpnProfile](/uwp/api/windows.networking.vpn.ivpnprofile) interface, such as [VpnNativeProfile](/uwp/api/windows.networking.vpn.vpnnativeprofile) or [VpnPlugInProfile](/uwp/api/windows.networking.vpn.vpnpluginprofile).
 
 ## -returns
+
 An enum value indicating the error status.
 
 ## -remarks
@@ -28,6 +33,6 @@ An enum value indicating the error status.
 
 ## -see-also
 
-
 ## -capabilities
+
 networkingVpnProvider

--- a/windows.networking.vpn/vpnmanagementagent_updateprofilefromobjectasync_1348691922.md
+++ b/windows.networking.vpn/vpnmanagementagent_updateprofilefromobjectasync_1348691922.md
@@ -12,6 +12,9 @@ public Windows.Foundation.IAsyncOperation<Windows.Networking.Vpn.VpnManagementEr
 ## -description
 Updates a VPN profile based on an input object.
 
+## -remarks
+A UWP VPN app can only update per-app profiles; it cannot update any other VPN profile. Apps that attempt to modify a per-user profile may instead create or modify a per-app profile; the new per-app profile will have the same name as the per-user profile.
+
 ## -parameters
 ### -param profile
 A **VpnProfile** object.


### PR DESCRIPTION
Per a bug that the team filed on itself -- it's confusing that an app can read a per-user profile, but when it's saved, a per-app profile is created instead. At the very least it should be documented