### PR TITLE
UWP VPN doesn't support StreamWebSocket

### DIFF
--- a/windows.networking.vpn/vpnchannel_setallowedssltlsversions_4693274.md
+++ b/windows.networking.vpn/vpnchannel_setallowedssltlsversions_4693274.md
@@ -14,7 +14,7 @@ Not supported.
 
 ## -parameters
 ### -param tunnelTransport
-An optional **IInspectable** object for socket transport. This object can be a [Windows.Networking.Sockets.DatagramSocket](/uwp/api/windows.networking.sockets.datagramsocket), a [Windows.Networking.Sockets.StreamSocket](/uwp/api/windows.networking.sockets.streamsocket), or a [Windows.Networking.Sockets.StreamWebSocket](/uwp/api/windows.networking.sockets.streamwebsocket). This socket controls the connection to the VPN server and will be used to send encapsulated IP packets and receive encapsulated data.
+An optional **IInspectable** object for socket transport. This object can be a [Windows.Networking.Sockets.DatagramSocket](/uwp/api/windows.networking.sockets.datagramsocket) or a [Windows.Networking.Sockets.StreamSocket](/uwp/api/windows.networking.sockets.streamsocket). This socket controls the connection to the VPN server and will be used to send encapsulated IP packets and receive encapsulated data.
 
 ### -param useTls12
 If Transport Security Layer 1.2 should be used, it is TRUE; otherwise, it is FALSE.


### PR DESCRIPTION
The original concept was to support them, but it was never implemented.