### PR TITLE
Removing references to StreamWebSocket from UWP VPN docs

### DIFF
--- a/windows.networking.vpn/vpnchannel_startwithtrafficfilter_794156625.md
+++ b/windows.networking.vpn/vpnchannel_startwithtrafficfilter_794156625.md
@@ -38,7 +38,7 @@ A UINT16 value specifying the max size of the frame defined by the VPN protocol 
 Reserved.
 
 ### -param transports
-A list of **IInspectable** objects for socket transport. Each object can be a [Windows.Networking.Sockets.DatagramSocket](/uwp/api/windows.networking.sockets.datagramsocket), a [Windows.Networking.Sockets.StreamSocket](/uwp/api/windows.networking.sockets.streamsocket), or a [Windows.Networking.Sockets.StreamWebSocket](/uwp/api/windows.networking.sockets.streamwebsocket). They will control the connection to the VPN server and will be used to send encapsulated IP packets and receive encapsulated data. The sockets must be unconnected at the point of the call.
+A list of **IInspectable** objects for socket transport. Each object can be a [Windows.Networking.Sockets.DatagramSocket](/uwp/api/windows.networking.sockets.datagramsocket) or a [Windows.Networking.Sockets.StreamSocket](/uwp/api/windows.networking.sockets.streamsocket). They will control the connection to the VPN server and will be used to send encapsulated IP packets and receive encapsulated data. The sockets must be unconnected at the point of the call.
 
 ### -param assignedTrafficFilters
 A **VpnTrafficFilterAssignment** object, which allows the specification of traffic filters to a VPN channel.


### PR DESCRIPTION
The original concept for UWP VPN included using StreamWebSockets; this was never implemented and should not be documented.