### PR TITLE
Always on is just always on capable, not fully always on

### DIFF
--- a/windows.networking.vpn/vpnnativeprofile_alwayson.md
+++ b/windows.networking.vpn/vpnnativeprofile_alwayson.md
@@ -10,12 +10,13 @@ public bool AlwaysOn { get;  set; }
 # Windows.Networking.Vpn.VpnNativeProfile.AlwaysOn
 
 ## -description
-Gets or sets a value that indicates whether the profile is for [Always On VPN](https://docs.microsoft.com/windows-server/remote/remote-access/vpn/always-on-vpn/).
+Gets or sets a value that indicates whether the profile is for [Always On VPN](https://docs.microsoft.com/windows-server/remote/remote-access/vpn/always-on-vpn/). If true, indicates that the VPN profile is capable of being always connected.
 
 ## -property-value
 `true` if the VPN profile is always connected, otherwise `false`.
 
 ## -remarks
+When set, the profile will be capable to being always on. The user must click the 'always connected' setting to make the profile be always-on.
 
 ## -examples
 

--- a/windows.networking.vpn/vpnnativeprofile_alwayson.md
+++ b/windows.networking.vpn/vpnnativeprofile_alwayson.md
@@ -10,18 +10,18 @@ public bool AlwaysOn { get;  set; }
 # Windows.Networking.Vpn.VpnNativeProfile.AlwaysOn
 
 ## -description
-Gets or sets a value that indicates whether the profile is for [Always On VPN](https://docs.microsoft.com/windows-server/remote/remote-access/vpn/always-on-vpn/). If true, indicates that the VPN profile is capable of being always connected.
+Gets or sets a value that indicates whether the VPN profile is for [Always-On VPN](/windows-server/remote/remote-access/vpn/always-on-vpn/); that is, whether the profile is *capable* of being always connected.
 
 ## -property-value
-`true` if the VPN profile is always connected, otherwise `false`.
+`true` if the VPN profile is *capable* of being always connected, otherwise `false`.
 
 ## -remarks
-When set, the profile will be capable to being always on. The user must click the 'always connected' setting to make the profile be always-on.
+When this property value has the value `true`, the profile is *capable* of being always-on; when the user also click the **always connected** setting, the profile *actually is* always-on.
 
 ## -examples
 
 ## -see-also
-[Remote Access Always On VPN](https://docs.microsoft.com/windows-server/remote/remote-access/vpn/always-on-vpn/)
+[Remote Access Always-On VPN](/windows-server/remote/remote-access/vpn/always-on-vpn/)
 
 ## -capabilities
 networkingVpnProvider


### PR DESCRIPTION
Documentation now makes is clear that the switch merely sets the profile to be always-on capable, not that the always-on switch will be turned on. The user needs to click the 'always connect' button to make the profile actually connect automatically.