### PR TITLE
PasswordBox: Improve documentation describing the visibility behavior of the password reveal button

### DIFF
--- a/windows.ui.xaml.controls/passwordbox.md
+++ b/windows.ui.xaml.controls/passwordbox.md
@@ -35,7 +35,7 @@ For more info, see [PasswordBox control guide](https://docs.microsoft.com/window
 
 ### Password reveal mode
 
-The [PasswordRevealMode](passwordbox_passwordrevealmode.md) property lets you customize the password viewing experience. By default, the PasswordBox has a built-in button that the user can press to display the password text. When the user releases it, the password is automatically hidden again.
+The [PasswordRevealMode](passwordbox_passwordrevealmode.md) property lets you customize the password viewing experience. By default, the PasswordBox has a built-in button that the user can press to display the password text. When the user releases it, the password is automatically hidden again. Note that due to security reasons that button is shown only when the PasswordBox receives focus for the first time and a character is entered. If the PasswordBox loses focus and then regains focus, the button is not shown again unless the password is cleared and character entry starts over.
 
 Windows 10, version 1607, introduces a new keyboard shortcut for accessibility. When the focus is in the PasswordBox and the password reveal button is visible, the user can press and hold Alt+F8 to reveal their password. When they let go of either key press, the password is hidden again.
 

--- a/windows.ui.xaml.controls/passwordbox_passwordrevealmode.md
+++ b/windows.ui.xaml.controls/passwordbox_passwordrevealmode.md
@@ -26,7 +26,7 @@ By default, the password reveal button (or "peek" button) is shown. The user mus
 
 <img src="images/PasswordBox_Revealed.png" alt="A password box with the password shown." />
 
-The value of this property is not the only factor that determines whether a password reveal button is visible to the user. Other factors include whether the control is displayed above a minimum width, whether the [PasswordBox](passwordbox.md) has focus, and whether the text entry field contains at least one character. The password reveal button is shown only when the [PasswordBox](passwordbox.md) receives focus for the first time and a character is entered. If the [PasswordBox](passwordbox.md) loses focus and then regains focus, the reveal button is not shown again unless the password is cleared and character entry starts over.
+The value of this property is not the only factor that determines whether a password reveal button is visible to the user. Other factors include whether the control is displayed above a minimum width, whether the [PasswordBox](passwordbox.md) has focus, and whether the text entry field contains at least one character. Note that due to security reasons the password reveal button is shown only when the [PasswordBox](passwordbox.md) receives focus for the first time and a character is entered. If the [PasswordBox](passwordbox.md) loses focus and then regains focus, the reveal button is not shown again unless the password is cleared and character entry starts over.
 
 > [!NOTE]
 > Prior to Windows 10, the password reveal button was not shown by default. If the security of your app requires that the password is always obscured, be sure to set PasswordRevealMode to **Hidden**.


### PR DESCRIPTION
This PR
* adds additional details about the visibility behavior of the password reveal button the PasswordBox's main documentation page
* adds explanation for the chosen visibility behavior to the documentation of the PasswordRevealMode API

Originally discussed in https://github.com/microsoft/microsoft-ui-xaml/issues/3252.

@YuliKl FYI.