### PR TITLE
Fix link to Auto-suggest accessibility on GetControlledPeers

### DIFF
--- a/windows.ui.xaml.automation/automationproperties_getcontrolledpeers_853183966.md
+++ b/windows.ui.xaml.automation/automationproperties_getcontrolledpeers_853183966.md
@@ -22,7 +22,7 @@ A list containing the peers that the target element controls.
 ## -remarks
 Examining controlled peers is an advanced scenario that most peer implementations won't need to use.
 
-This identifier is commonly used for [Auto-suggest accessibility](https://windowsstyleguide/accessibility/accessible-text-requirements/#auto-suggest_accessibility).
+This identifier is commonly used for [Auto-suggest accessibility](https://docs.microsoft.com/en-us/windows/uwp/design/accessibility/accessible-text-requirements#auto-suggest-accessibility).
 
 ## -examples
 


### PR DESCRIPTION
The style guide is available at https://docs.microsoft.com/en-us/windows/uwp/design. Updating the broken link to match that.