### PR TITLE
UIElement key event pipeline: Missing event in list correction

### DIFF
--- a/windows.ui.xaml/uielement_characterreceived.md
+++ b/windows.ui.xaml/uielement_characterreceived.md
@@ -57,6 +57,7 @@ The CharacterReceived event can occur at different times depending on the charac
   - KeyUp for 1
   - PreviewKeyDown for 6
   - KeyDown for 6
+  - CharacterReceived
   - PreviewKeyUp for 6
   - KeyUp for 6
   - PreviewKeyDown for 4


### PR DESCRIPTION
See [this](https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.uielement.characterreceived?view=winrt-19041#remarks) page, under _User presses Alt+164 using the NumPad (the character ‘ñ’ is received)_, the `CharacterReceived` event is missing.