### PR TITLE
Link most drag & drop APIs to the UWP drag & drop overview

### DIFF
--- a/windows.ui.xaml.controls/listviewbase_canreorderitems.md
+++ b/windows.ui.xaml.controls/listviewbase_canreorderitems.md
@@ -50,7 +50,4 @@ Here's a [GridView](gridview.md) that contains 6 rectangles that a user can reor
 
 ## -see-also
 
-+ [AllowDrop](../windows.ui.xaml/uielement_allowdrop.md)
-+ [CanDragItems](listviewbase_candragitems.md)
-+ [Drag and drop overview](windows/uwp/design/input/drag-and-drop)
-+ [Drag and drop sample (Windows 10)](https://github.com/Microsoft/Windows-universal-samples/tree/master/Samples/XamlDragAndDrop)
+[AllowDrop](../windows.ui.xaml/uielement_allowdrop.md), [CanDragItems](listviewbase_candragitems.md), [Drag and drop overview](/windows/uwp/design/input/drag-and-drop), [Drag and drop sample (Windows 10)](https://github.com/Microsoft/Windows-universal-samples/tree/master/Samples/XamlDragAndDrop)

--- a/windows.ui.xaml.controls/listviewbase_canreorderitems.md
+++ b/windows.ui.xaml.controls/listviewbase_canreorderitems.md
@@ -48,7 +48,9 @@ Here's a [GridView](gridview.md) that contains 6 rectangles that a user can reor
 </GridView>
 ```
 
-
-
 ## -see-also
-[AllowDrop](../windows.ui.xaml/uielement_allowdrop.md), [CanDragItems](listviewbase_candragitems.md), [Drag and drop sample (Windows 10)](https://github.com/Microsoft/Windows-universal-samples/tree/master/Samples/XamlDragAndDrop)
+
++ [AllowDrop](../windows.ui.xaml/uielement_allowdrop.md)
++ [CanDragItems](listviewbase_candragitems.md)
++ [Drag and drop overview](windows/uwp/design/input/drag-and-drop)
++ [Drag and drop sample (Windows 10)](https://github.com/Microsoft/Windows-universal-samples/tree/master/Samples/XamlDragAndDrop)

--- a/windows.ui.xaml/uielement_allowdrop.md
+++ b/windows.ui.xaml/uielement_allowdrop.md
@@ -37,5 +37,4 @@ A UI element can't be a drop target for any drag-drop action that begins from ou
 
 ## -see-also
 
-+ [Drag and drop overview](windows/uwp/design/input/drag-and-drop)
-+ [Drag and drop sample (Windows 10)](https://github.com/Microsoft/Windows-universal-samples/tree/master/Samples/XamlDragAndDrop)
+[Drag and drop overview](/windows/uwp/design/input/drag-and-drop), [Drag and drop sample (Windows 10)](https://github.com/Microsoft/Windows-universal-samples/tree/master/Samples/XamlDragAndDrop)

--- a/windows.ui.xaml/uielement_allowdrop.md
+++ b/windows.ui.xaml/uielement_allowdrop.md
@@ -36,4 +36,6 @@ A UI element can't be a drop target for any drag-drop action that begins from ou
 ## -examples
 
 ## -see-also
-[Drag and drop sample (Windows 10)](https://github.com/Microsoft/Windows-universal-samples/tree/master/Samples/XamlDragAndDrop)
+
++ [Drag and drop overview](windows/uwp/design/input/drag-and-drop)
++ [Drag and drop sample (Windows 10)](https://github.com/Microsoft/Windows-universal-samples/tree/master/Samples/XamlDragAndDrop)

--- a/windows.ui.xaml/uielement_candrag.md
+++ b/windows.ui.xaml/uielement_candrag.md
@@ -26,5 +26,4 @@ Gets or sets a value that indicates whether the element can be dragged as data i
 
 ## -see-also
 
-+ [Drag and drop overview](windows/uwp/design/input/drag-and-drop)
-+ [Drag and drop sample (Windows 10)](https://github.com/Microsoft/Windows-universal-samples/tree/master/Samples/XamlDragAndDrop)
+[Drag and drop overview](/windows/uwp/design/input/drag-and-drop), [Drag and drop sample (Windows 10)](https://github.com/Microsoft/Windows-universal-samples/tree/master/Samples/XamlDragAndDrop)

--- a/windows.ui.xaml/uielement_candrag.md
+++ b/windows.ui.xaml/uielement_candrag.md
@@ -25,3 +25,6 @@ Gets or sets a value that indicates whether the element can be dragged as data i
 ## -examples
 
 ## -see-also
+
++ [Drag and drop overview](windows/uwp/design/input/drag-and-drop)
++ [Drag and drop sample (Windows 10)](https://github.com/Microsoft/Windows-universal-samples/tree/master/Samples/XamlDragAndDrop)

--- a/windows.ui.xaml/uielement_dragover.md
+++ b/windows.ui.xaml/uielement_dragover.md
@@ -42,5 +42,4 @@ Independent of the event occurrence, some controls may use theme animations such
 
 ## -see-also
 
-+ [DragEventArgs](drageventargs.md), [DragEnter](uielement_dragenter.md), [AllowDrop](uielement_allowdrop.md), [Events and routed events overview](/windows/uwp/xaml-platform/events-and-routed-events-overview)
-+ [Drag and drop overview](windows/uwp/design/input/drag-and-drop)
+[DragEventArgs](drageventargs.md), [DragEnter](uielement_dragenter.md), [AllowDrop](uielement_allowdrop.md), [Events and routed events overview](/windows/uwp/xaml-platform/events-and-routed-events-overview), [Drag and drop overview](/windows/uwp/design/input/drag-and-drop)

--- a/windows.ui.xaml/uielement_dragover.md
+++ b/windows.ui.xaml/uielement_dragover.md
@@ -42,4 +42,5 @@ Independent of the event occurrence, some controls may use theme animations such
 
 ## -see-also
 
-[DragEventArgs](drageventargs.md), [DragEnter](uielement_dragenter.md), [AllowDrop](uielement_allowdrop.md), [Events and routed events overview](/windows/uwp/xaml-platform/events-and-routed-events-overview)
++ [DragEventArgs](drageventargs.md), [DragEnter](uielement_dragenter.md), [AllowDrop](uielement_allowdrop.md), [Events and routed events overview](/windows/uwp/xaml-platform/events-and-routed-events-overview)
++ [Drag and drop overview](windows/uwp/design/input/drag-and-drop)

--- a/windows.ui.xaml/uielement_drop.md
+++ b/windows.ui.xaml/uielement_drop.md
@@ -44,6 +44,4 @@ Independent of the event occurrence, some controls may use theme animations such
 
 ## -see-also
 
-+ [DragEventArgs](drageventargs.md), [DragOver](uielement_dragover.md), [AllowDrop](uielement_allowdrop.md), [Events and routed events overview](/windows/uwp/xaml-platform/events-and-routed-events-overview)
-+ [Drag and drop overview](windows/uwp/design/input/drag-and-drop)
-+ [Drag and drop sample (Windows 10)](https://github.com/Microsoft/Windows-universal-samples/tree/master/Samples/XamlDragAndDrop)
+[DragEventArgs](drageventargs.md), [DragOver](uielement_dragover.md), [AllowDrop](uielement_allowdrop.md), [Events and routed events overview](/windows/uwp/xaml-platform/events-and-routed-events-overview), [Drag and drop overview](/windows/uwp/design/input/drag-and-drop), [Drag and drop sample (Windows 10)](https://github.com/Microsoft/Windows-universal-samples/tree/master/Samples/XamlDragAndDrop)

--- a/windows.ui.xaml/uielement_drop.md
+++ b/windows.ui.xaml/uielement_drop.md
@@ -44,4 +44,6 @@ Independent of the event occurrence, some controls may use theme animations such
 
 ## -see-also
 
-[DragEventArgs](drageventargs.md), [DragOver](uielement_dragover.md), [AllowDrop](uielement_allowdrop.md), [Events and routed events overview](/windows/uwp/xaml-platform/events-and-routed-events-overview), [Drag and drop sample (Windows 10)](https://github.com/Microsoft/Windows-universal-samples/tree/master/Samples/XamlDragAndDrop)
++ [DragEventArgs](drageventargs.md), [DragOver](uielement_dragover.md), [AllowDrop](uielement_allowdrop.md), [Events and routed events overview](/windows/uwp/xaml-platform/events-and-routed-events-overview)
++ [Drag and drop overview](windows/uwp/design/input/drag-and-drop)
++ [Drag and drop sample (Windows 10)](https://github.com/Microsoft/Windows-universal-samples/tree/master/Samples/XamlDragAndDrop)

--- a/windows.ui.xaml/uielement_dropevent.md
+++ b/windows.ui.xaml/uielement_dropevent.md
@@ -20,4 +20,7 @@ The identifier for the [Drop](uielement_drop.md) routed event.
 ## -examples
 
 ## -see-also
-[AddHandler](uielement_addhandler_2121467075.md), [Events and routed events overview](/windows/uwp/xaml-platform/events-and-routed-events-overview)
+
++ [Events and routed events overview](/windows/uwp/xaml-platform/events-and-routed-events-overview)
++ [AddHandler](uielement_addhandler_2121467075.md)
++ [Drag and drop overview](windows/uwp/design/input/drag-and-drop)

--- a/windows.ui.xaml/uielement_dropevent.md
+++ b/windows.ui.xaml/uielement_dropevent.md
@@ -21,6 +21,4 @@ The identifier for the [Drop](uielement_drop.md) routed event.
 
 ## -see-also
 
-+ [Events and routed events overview](/windows/uwp/xaml-platform/events-and-routed-events-overview)
-+ [AddHandler](uielement_addhandler_2121467075.md)
-+ [Drag and drop overview](windows/uwp/design/input/drag-and-drop)
+[Events and routed events overview](/windows/uwp/xaml-platform/events-and-routed-events-overview), [AddHandler](uielement_addhandler_2121467075.md), [Drag and drop overview](/windows/uwp/design/input/drag-and-drop)


### PR DESCRIPTION
I went through [the UWP drag and drop overview](https://docs.microsoft.com/en-us/windows/uwp/design/input/drag-and-drop) and added links back to the overview for all the relevant properties I could find.