### PR TITLE
document null return case from User::GetPictureAsync()

### DIFF
--- a/windows.system/user_getpictureasync_2117608675.md
+++ b/windows.system/user_getpictureasync_2117608675.md
@@ -17,7 +17,7 @@ Gets a user's picture asynchronously.
 The desired size of the user's picture to return.
 
 ## -returns
-When this method completes, it returns the user's picture.
+When this method completes, it returns the user's picture or null if there is none.
 
 ## -remarks
 


### PR DESCRIPTION
the [samples](https://github.com/microsoft/Windows-universal-samples/blob/master/Samples/UserInfo/cs/Scenario1_FindUsers.xaml.cs#L101), and much of the code in the OS repo, show that this can be null
