### PR TITLE
[ItemPanel] Clarify it's important to use the correct StackPanel type

### DIFF
--- a/windows.ui.xaml.controls/itemscontrol_itemspanel.md
+++ b/windows.ui.xaml.controls/itemscontrol_itemspanel.md
@@ -31,6 +31,8 @@ Gets or sets the template that defines the panel that controls the layout of ite
 ## -property-value
 An [ItemsPanelTemplate](itemspaneltemplate.md) that defines the panel to use for the layout of the items. The default value for the [ItemsControl](itemscontrol.md) is an [ItemsPanelTemplate](itemspaneltemplate.md) that specifies a [StackPanel](stackpanel.md).
 
+Subtypes of ItemsControl may use different default ItemsPanelTemplates. For example, [ListView](/uwp/api/windows.ui.xaml.controls.listview)s by default use an [ItemsStackPanel](/uwp/api/Windows.UI.Xaml.Controls.ItemsStackPanel). Using a different type may cause unexpected behavior; for example using a plain StackPanel as the ListView's ItemsPanel can regress Narrator behavior during drag and drop.
+
 ## -remarks
 > [!NOTE]
 > [ComboBox](combobox.md) uses a [CarouselPanel](../windows.ui.xaml.controls.primitives/carouselpanel.md) as its ItemsPanel. Using a different panel as the ItemsPanel of [ComboBox](combobox.md) is not supported and might result in undesired behavior.


### PR DESCRIPTION
Today, the documentation for ItemsPanel lists the default value for ItemsControls, but does not mention that common controls (like ListView) override this default value. If users use the incorrect panel type here, they may regress behavior (for example, Narrator keyboard reordering notifications via `CanReorderItems` on a ListView will not have the correct info).

This change updates the documentation to clarify that subtypes of ItemsControl may have different default templates, and it also clarifies that using the wrong type may cause unexpected behavior.

## Further information

>  ItemsStackPanel is the default ItemsPanel for ListView.

[ItemsStackPanel](https://docs.microsoft.com/en-us/uwp/api/Windows.UI.Xaml.Controls.ItemsStackPanel?view=winrt-19041)

