### PR TITLE
Corrected description of the Value of ExposureControl

### DIFF
--- a/windows.media.devices/exposurecontrol_max.md
+++ b/windows.media.devices/exposurecontrol_max.md
@@ -10,10 +10,10 @@ public Windows.Foundation.TimeSpan Max { get; }
 # Windows.Media.Devices.ExposureControl.Max
 
 ## -description
-Gets the maximum exposure time.
+The maximum EV compensation supported.
 
 ## -property-value
-The maximum exposure time.
+The maximum EV compensation supported. This is an absolute EV value.
 
 ## -remarks
 

--- a/windows.media.devices/exposurecontrol_min.md
+++ b/windows.media.devices/exposurecontrol_min.md
@@ -10,10 +10,10 @@ public Windows.Foundation.TimeSpan Min { get; }
 # Windows.Media.Devices.ExposureControl.Min
 
 ## -description
-Gets the minimum exposure time.
+Gets the minimum EV compensation supported.
 
 ## -property-value
-The minimum exposure time.
+The minimum EV compensation supported. This is an absolute EV value.
 
 ## -remarks
 

--- a/windows.media.devices/exposurecontrol_value.md
+++ b/windows.media.devices/exposurecontrol_value.md
@@ -10,10 +10,10 @@ public Windows.Foundation.TimeSpan Value { get; }
 # Windows.Media.Devices.ExposureControl.Value
 
 ## -description
-Gets the exposure time.
+Gets the EV compensation value.
 
 ## -property-value
-The exposure time.
+The EV compensation value.
 
 ## -remarks
 To set an exposure value, call [SetValueAsync](exposurecontrol_setvalueasync_1247308686.md) specifying a value between the [Min](exposurecontrol_min.md) and [Max](exposurecontrol_max.md) exposure values. To turn auto exposure on, call [SetAutoAsync](exposurecontrol_setautoasync_1168787363.md).


### PR DESCRIPTION
Previously, the Value was described as an exposure time, when it is actually the Exposure Value (EV) of the camera https://en.wikipedia.org/wiki/Exposure_value
Also updated description for Min and Max.