### PR TITLE
Host backdrop brush can be not translucent

### DIFF
--- a/windows.ui.composition/compositor_createhostbackdropbrush_565383631.md
+++ b/windows.ui.composition/compositor_createhostbackdropbrush_565383631.md
@@ -18,7 +18,7 @@ Returns the created CompositionBackdropBrush.
 ## -remarks
 The standard backdrop brush samples the area immediately behind the visual where it is used. The host backdrop brush tells the compositor to sample from the area behind the visual, before the window is drawn. By default, the host backdrop brush is translucent and it hit-tests as opaque. The app cannot read the pixel data back.
 
-The transparency of the host backdrop brush is a property which can be controlled by the user from Settings or through power policies.
+The transparency of the host backdrop brush is a property the user can control from **Settings** or by using power policies.
 
 ## -see-also
 

--- a/windows.ui.composition/compositor_createhostbackdropbrush_565383631.md
+++ b/windows.ui.composition/compositor_createhostbackdropbrush_565383631.md
@@ -16,7 +16,9 @@ Creates an instance of  CompositionBackdropBrush that samples from the area behi
 Returns the created CompositionBackdropBrush.
 
 ## -remarks
-The standard backdrop brush samples the area immediately behind the visual where it is used. The host backdrop brush tells the compositor to sample from the area behind the visual, before the window is drawn. The host backdrop brush is translucent and it hit-tests as opaque. The app cannot read the pixel data back. 
+The standard backdrop brush samples the area immediately behind the visual where it is used. The host backdrop brush tells the compositor to sample from the area behind the visual, before the window is drawn. By default, the host backdrop brush is translucent and it hit-tests as opaque. The app cannot read the pixel data back.
+
+The transparency of the host backdrop brush is a property which can be controlled by the user from Settings or through power policies.
 
 ## -see-also
 


### PR DESCRIPTION
The host backdrop brush transparency can be controlled through the Settings UI or through power policies. Added this information to the remarks section.