### PR TITLE
Update TryGetMonitor docs to clarify return

### DIFF
--- a/windows.devices.display.core/displaytarget_trygetmonitor_1984556141.md
+++ b/windows.devices.display.core/displaytarget_trygetmonitor_1984556141.md
@@ -11,11 +11,15 @@ public DisplayMonitor DisplayTarget.TryGetMonitor()
 # Windows.Devices.Display.Core.DisplayTarget.TryGetMonitor
 
 ## -description
-Tries to retrieve an object describing the monitor currently connected to this [DisplayTarget](displaytarget.md). This method can fail or return a different monitor than the properties on the **DisplayTarget** describe if monitors have been plugged or unplugged from the **DisplayTarget** since the **DisplayTarget** object was created. **IsStale** returns true if the monitor has changed since the **DisplayTarget** was created.
+Tries to retrieve an object describing the monitor currently connected to this [DisplayTarget](displaytarget.md). This method can fail or return a different monitor than the properties on the **DisplayTarget** describe if monitors have been plugged or unplugged from the **DisplayTarget** since the **DisplayTarget** object was created. **IsStale** returns true if the monitor *may* have changed since the **DisplayTarget** was created.
 
 ## -returns
 
+A [DisplayMonitor](../windows.devices.display/displaymonitor.md) representing the monitor connected to this target, if one is connected, or else **null** if nothing is connected.
+
 ## -remarks
+
+Note that since this method is named with **Try**, it returns **null** instead of throwing an exception or returning a failure HRESULT.
 
 ## -see-also
 

--- a/windows.devices.display.core/displaytarget_trygetmonitor_1984556141.md
+++ b/windows.devices.display.core/displaytarget_trygetmonitor_1984556141.md
@@ -11,7 +11,7 @@ public DisplayMonitor DisplayTarget.TryGetMonitor()
 # Windows.Devices.Display.Core.DisplayTarget.TryGetMonitor
 
 ## -description
-Tries to retrieve an object describing the monitor currently connected to this [DisplayTarget](displaytarget.md). This method can fail or return a different monitor than the properties on the **DisplayTarget** describe if monitors have been plugged or unplugged from the **DisplayTarget** since the **DisplayTarget** object was created. **IsStale** returns true if the monitor *may* have changed since the **DisplayTarget** was created.
+Tries to retrieve an object describing the monitor currently connected to this [DisplayTarget](displaytarget.md). This method can fail or return a different monitor than the properties on the **DisplayTarget** describe if monitors have been plugged or unplugged from the **DisplayTarget** since the **DisplayTarget** object was created. **IsStale** returns true if the monitor *might* have changed since the **DisplayTarget** was created.
 
 ## -returns
 
@@ -19,7 +19,7 @@ A [DisplayMonitor](../windows.devices.display/displaymonitor.md) representing th
 
 ## -remarks
 
-Note that since this method is named with **Try**, it returns **null** instead of throwing an exception or returning a failure HRESULT.
+Since this method has **Try** in its name, it returns **null** instead of throwing an exception or returning a failure HRESULT.
 
 ## -see-also
 


### PR DESCRIPTION
Clarify that TryGetMonitor returns null rather than throwing or returning a non-S_OK value.