### PR TITLE
Included details about animatable properties on most wincomp pages (and fix some formatting)

### DIFF
--- a/windows.ui.composition/compositionanimation.md
+++ b/windows.ui.composition/compositionanimation.md
@@ -22,6 +22,8 @@ Use the [CompostionObject.StartAnimation](compositionobject_startanimation_70905
 
 Value parameters (as opposed to reference parameters which are set using [SetReferenceParameter](compositionanimation_setreferenceparameter_486390519.md)) are copied and "embedded" into an expression at the time [CompositionObject.StartAnimation](compositionobject_startanimation_709050842.md) is called. Changing the value of the variable after [CompositionObject.StartAnimation](compositionobject_startanimation_709050842.md) is called will not affect the value of the [ExpressionAnimation](expressionanimation.md). See the remarks section of [ExpressionAnimation](expressionanimation.md) for additional information.
 
+For a list of animatable properties, see the remarks on [CompostionObject.StartAnimation](compositionobject_startanimation_709050842.md).
+
 ### Version history
 
 | Windows version | SDK version | Value added |

--- a/windows.ui.composition/compositionanimation_target.md
+++ b/windows.ui.composition/compositionanimation_target.md
@@ -17,6 +17,8 @@ Equivalent WinUI property: [Microsoft.UI.Composition.CompositionAnimation.Target
 ## -property-value
 The target of the animation.
 
+For a list of animatable properties, see the remarks on [CompostionObject.StartAnimation](compositionobject_startanimation_709050842.md).
+
 ## -remarks
 
 ## -examples

--- a/windows.ui.composition/expressionanimation.md
+++ b/windows.ui.composition/expressionanimation.md
@@ -22,6 +22,8 @@ For a detailed walkthrough of using Composition ExpressionAnimation, check out t
 
 Use the [CompostionObject.StartAnimation](compositionobject_startanimation_709050842.md) and [CompostionObject.StopAnimation](compositionobject_stopanimation_1075337060.md) methods to start and stop the animation.
 
+For a list of animatable properties, see the remarks on [CompostionObject.StartAnimation](compositionobject_startanimation_709050842.md).
+
 ### So why are Expression Animations useful?
 
 The real power of Expression Animations comes from their ability to create a mathematical relationship with references to properties on other objects. This means you can have an equation referencing property values on other Composition objects, local variables, or even shared values in Composition Property Sets. As these references change and update over time, your expression will as well. This opens up bigger possibilities beyond traditional KeyFrame Animations where values must be discrete and pre-defined – ExpressionAnimations can make more dynamic animation experiences.

--- a/windows.ui.composition/expressionanimation.md
+++ b/windows.ui.composition/expressionanimation.md
@@ -31,8 +31,9 @@ The real power of Expression Animations comes from their ability to create a mat
 ### Things to Note
 
 + ExpressionAnimation has an infinite lifetime – they will continue to run until they are explicitly stopped.
-+ The mathematical equation will be input into the expression as a string – this can be done when constructing the ExpressionAnimation or separately by changing the property. If done during construction, the property will be set.    + ExpressionAnimation exp = _compositor.CreateExpressionAnimation(); exp.Expression = "this.Target.Offset.X / xWindowSize";
-   + ExpressionAnimation exp = _compositor.CreateExpressionAnimation("this.Target.Offset.X / xWindowSize")
++ The mathematical equation will be input into the expression as a string – this can be done when constructing the ExpressionAnimation or separately by changing the property. If done during construction, the property will be set.
+   + `ExpressionAnimation exp = _compositor.CreateExpressionAnimation(); exp.Expression = "this.Target.Offset.X / xWindowSize";`
+   + `ExpressionAnimation exp = _compositor.CreateExpressionAnimation("this.Target.Offset.X / xWindowSize");`
 
 + The mathematical equation will be used every frame to calculate the value of the animating property (this is in stark contrast to [KeyFrameAnimation](keyframeanimation.md)s that use an interpolator)
 + Pay attention to the type of the property you plan to animate – your equation must resolve to the same type. Otherwise, an error will get thrown when the expression gets calculated. If your equation resolves to Nan (number/0), the system will use the previously calculated value
@@ -49,20 +50,25 @@ When attached to an animating property, the system will use this equation to cal
 When constructing the mathematical equation, there are a number of different components to keep in mind (For a detailed walkthrough of each of these components, see the Animation Overview):
 
 
-+ Operators, Precedence and Associativity    + The Expression string supports usage of typical mathematical operators (+, -, /, , etc.) you would expect to use in any equation.
++ Operators, Precedence and Associativity
+   + The Expression string supports usage of typical mathematical operators (+, -, /, , etc.) you would expect to use in any equation.
    + When the expression is evaluated, it will adhere to operator precedence and associativity as defined in the C# language specification.
 
-+ Property Parameters    + When defining your Expression, you have the option to define type references to other properties on Composition Visuals, Property Sets or other C# objects.
++ Property Parameters
+   + When defining your Expression, you have the option to define type references to other properties on Composition Visuals, Property Sets or other C# objects.
    + To use in an expression string, utilize the “SetParameter” functions based on type, defining the string utilized in the expression string and its mapped value. These functions are listed as part of the top level [CompositionAnimation](compositionanimation.md) class.
 
-+ Helper Functions and Constructors    + The Expression can also leverage a list of functions and constructors for different object types in the equation.
++ Helper Functions and Constructors
+   + The Expression can also leverage a list of functions and constructors for different object types in the equation.
    + There are also constructor methods that will construct an object type when the equation is evaluated by the system
    + A list of the functions per type is listed further below
 
-+ Keywords    + The Expression also can take advantage of a number of keywords that are treated differently when the Expression String Is evaluated. Consider these keywords and cannot be used as a string key in property references.
++ Keywords
+   + The Expression also can take advantage of a number of keywords that are treated differently when the Expression String Is evaluated. Consider these keywords and cannot be used as a string key in property references.
    + List of available keywords listed further below
 
-+ Conditionals    + An expression can also utilize conditional statements using the Ternary operator (condition ? ifTrue_expression : ifFalse_expression)
++ Conditionals
+   + An expression can also utilize conditional statements using the Ternary operator (condition ? ifTrue_expression : ifFalse_expression)
    + Ternary operators can be nested as the expression for the true or false statements.
 
 


### PR DESCRIPTION
Today, only one page documents which properties are animatable using WinComp APIs.

This change adds more links to this page, so readers can more easily discover what properties they can animate. It also fixes some list formatting.