### PR TITLE
Fix links in ListViewBase.SelectionMode table

### DIFF
--- a/windows.ui.xaml.controls/listviewbase_selectionmode.md
+++ b/windows.ui.xaml.controls/listviewbase_selectionmode.md
@@ -28,18 +28,18 @@ One of the [ListViewSelectionMode](listviewselectionmode.md) enumeration values.
 
 ## -remarks
 By default, a user can select a single item in a view. You can set the SelectionMode property to a [ListViewSelectionMode](listviewselectionmode.md) enumeration value to enable multi-selection or to disable selection. Here are the selection mode values.<table>
-   <tr><td>[None](listviewselectionmode.md)</td><td>Item selection is disabled.</td></tr>
-   <tr><td>[Single](listviewselectionmode.md)</td><td>With no modifier keys:
+   <tr><td><a href="listviewselectionmode.md">None</a></td><td>Item selection is disabled.</td></tr>
+   <tr><td><a href="listviewselectionmode.md">Single</a></td><td>With no modifier keys:
 
 <ul><li>A user can select a single item using the space bar, mouse click, or touch tap.</li><li>A user can deselect an item using a downward swipe gesture.</li></ul>While pressing Ctrl:
 
 <ul><li>A user can deselect the item by using the space bar, mouse click, or touch tap.</li><li>Using the arrow keys, a user can move focus independently of selection.</li></ul></td></tr>
-   <tr><td>[Multiple](listviewselectionmode.md)</td><td>With no modifier keys:
+   <tr><td><a href="listviewselectionmode.md">Multiple</a></td><td>With no modifier keys:
 
 <ul><li>A user can select multiple items using the space bar, mouse click, or touch tap to toggle selection on the focused item.</li><li>Using the arrow keys, a user can move focus independently of selection.</li></ul></td></tr>
-   <tr><td>[Extended](listviewselectionmode.md)</td><td>With no modifier keys:
+   <tr><td><a href="listviewselectionmode.md">Extended</a></td><td>With no modifier keys:
 
-<ul><li>The behavior is the same as [Single](listviewselectionmode.md) selection.</li></ul>While pressing Ctrl:
+<ul><li>The behavior is the same as <a href="listviewselectionmode.md">Single</a> selection.</li></ul>While pressing Ctrl:
 
 <ul><li>A user can select multiple items using the space bar, mouse click, or touch tap to toggle selection on the focused item.</li><li>Using the arrow keys, a user can move focus independently of selection.</li></ul>While pressing Shift:
 


### PR DESCRIPTION
When using <td> tags, markdown inside them does not properly work without empty lines between them. To fix the faulty links, we are using <a> tags now. Fixes #2077 