### PR TITLE
Fix links in search suggestion kind tables

### DIFF
--- a/windows.applicationmodel.search.core/searchsuggestion_kind.md
+++ b/windows.applicationmodel.search.core/searchsuggestion_kind.md
@@ -20,11 +20,11 @@ If the suggestion was supplied by the system, it has a [SearchSuggestionKind](se
 
 <table>
    <tr><th>SearchSuggestionCollection method</th><th>SearchSuggestionKind</th></tr>
-   <tr><td>[AppendQuerySuggestion](../windows.applicationmodel.search/searchsuggestioncollection_appendquerysuggestion_1406009690.md)</td><td>**Query**</td></tr>
-   <tr><td>[AppendQuerySuggestions](../windows.applicationmodel.search/searchsuggestioncollection_appendquerysuggestions_81953608.md)</td><td>**Query**</td></tr>
-   <tr><td>[AppendResultSuggestion](../windows.applicationmodel.search/searchsuggestioncollection_appendresultsuggestion_603544202.md)</td><td>**Result**</td></tr>
-   <tr><td>[AppendSearchSeparator](../windows.applicationmodel.search/searchsuggestioncollection_appendsearchseparator_842802100.md)</td><td>**Separator**</td></tr>
-   <tr><td>[AppendStorageFile](../windows.applicationmodel.search/searchsuggestioncollection_appendstoragefilesuggestion.md)</td><td>**StorageFile**</td></tr>
+   <tr><td><a href="../windows.applicationmodel.search/searchsuggestioncollection_appendquerysuggestion_1406009690.md">AppendQuerySuggestion</a></td><td>**Query**</td></tr>
+   <tr><td><a href="../windows.applicationmodel.search/searchsuggestioncollection_appendquerysuggestions_81953608.md">AppendQuerySuggestions</a></td><td>**Query**</td></tr>
+   <tr><td><a href="../windows.applicationmodel.search/searchsuggestioncollection_appendresultsuggestion_603544202.md">AppendResultSuggestion</a></td><td>**Result**</td></tr>
+   <tr><td><a href="../windows.applicationmodel.search/searchsuggestioncollection_appendsearchseparator_842802100.md">AppendSearchSeparator</a></td><td>**Separator**</td></tr>
+   <tr><td><a href="../windows.applicationmodel.search/searchsuggestioncollection_appendstoragefilesuggestion.md">AppendStorageFile</a></td><td>**StorageFile**</td></tr>
 </table>
 
 ## -examples


### PR DESCRIPTION
When using tags, markdown inside them does not properly work without empty lines between them. To fix the faulty links, we are using tags now. Fixes #2079