### PR TITLE
Update webaccount_getpictureasync_202157661.md

### DIFF
--- a/windows.security.credentials/webaccount_getpictureasync_202157661.md
+++ b/windows.security.credentials/webaccount_getpictureasync_202157661.md
@@ -23,6 +23,8 @@ When this method completes, it returns the web account's picture.
 ## -remarks
 The word "desired" is misspelled in this parameter name.
 
+This method should be called on [WebAccount](webaccount.md) returned in [WebTokenRequestResponse](webtokenrequestresponse.md) with ("UserPictureEnabled", "True") inserted in [WebTokenRequest.Properties](webtokenrequest_properties.md) while creating [WebTokenRequest](webtokenrequest.md) for acquirung token or else it might return default profile picture.
+
 ## -examples
 
 ## -see-also

--- a/windows.security.credentials/webaccount_getpictureasync_202157661.md
+++ b/windows.security.credentials/webaccount_getpictureasync_202157661.md
@@ -23,7 +23,7 @@ When this method completes, it returns the web account's picture.
 ## -remarks
 The word "desired" is misspelled in this parameter name.
 
-This method should be called on [WebAccount](webaccount.md) returned in [WebTokenRequestResponse](webtokenrequestresponse.md) with ("UserPictureEnabled", "True") inserted in [WebTokenRequest.Properties](webtokenrequest_properties.md) while creating [WebTokenRequest](webtokenrequest.md) for acquirung token or else it might return default profile picture.
+This method should be called on the [WebAccount](webaccount.md) returned in [WebTokenRequestResponse](webtokenrequestresponse.md). Add (`UserPictureEnabled`, `True`) to the [WebTokenRequest.Properties](webtokenrequest_properties.md) while creating [WebTokenRequest](webtokenrequest.md) to acquire a token. Otherwise, the call may return a default profile picture.
 
 ## -examples
 


### PR DESCRIPTION
The api GetPictureAsync returns a badge icon otherwise for AAD account. We need to add "UserPictureEnabled" property to retrieve the correct profile picture for a web account and should get called on web account retrieved from web token response while acquiring token.