### PR TITLE
Update the notice in the MessageDialog documentation to be technically correct

### DIFF
--- a/windows.ui.popups/messagedialog.md
+++ b/windows.ui.popups/messagedialog.md
@@ -16,7 +16,7 @@ Represents a dialog for showing messages to the user.
 ## -remarks
 
 > [!IMPORTANT]
-> You should use MessageDialog only when you are upgrading a Universal Windows 8 app that uses MessageDialog, and need to minimize changes. For new apps in Windows 10, we recommend using the [ContentDialog](./../windows.ui.xaml.controls/contentdialog.md) control instead.
+> You should use MessageDialog only when you are upgrading a Universal Windows 8.x app that uses MessageDialog, and need to minimize changes or if your app isn't XAML. For new XAML apps in Windows 10+, we recommend using the [ContentDialog](./../windows.ui.xaml.controls/contentdialog.md) control instead.
 
 <!-- confirmed -->
 > [!NOTE]


### PR DESCRIPTION
`ContentDialog` works only in XAML apps while `MessageDialog` works in any UWP app so I updated the notice about recommending replacing `MessageDialog` with `ContentDialog` to indicate that it's for XAML apps only.