### PR TITLE
Fix conflicts on IVector<T> documentation

### DIFF
--- a/windows.foundation.collections/ivector_1.md
+++ b/windows.foundation.collections/ivector_1.md
@@ -46,10 +46,5 @@ IVector inherits [IIterable](iiterable_1.md). Types that implement IVector also 
 ## -examples
 
 ## -see-also
-<<<<<<< HEAD
-[Collections (C++/CX)](/cpp/cppcx/collections-c-cx), [System.Collections.Generic.IList\<T\>](/dotnet/api/system.collections.generic.ilist-1)
-[Collections (C++/CX)](/cpp/cppcx/collections-c-cx), [System.Collections.Generic.IList\<T\>](/dotnet/api/system.collections.generic.ilist-1)
-=======
 
 [Collections (C++/CX)](/cpp/cppcx/collections-c-cx), [System.Collections.Generic.IList<T>](/dotnet/api/system.collections.generic.ilist-1?view=dotnet-uwp-10.0&preserve-view=true)
->>>>>>> cd84458f70e29e2fa6b720ec78056581fa3bce0b

--- a/windows.foundation.collections/ivector_1.md
+++ b/windows.foundation.collections/ivector_1.md
@@ -41,10 +41,10 @@ Returns an iterator to one past the last element of the collection, for use in C
 
 ### Interface inheritance
 
-IVector inherits [IIterable](iiterable_1.md). Types that implement IVector also implement the interface members of [IIterable](iiterable_1.md). Similarly, if you're using .NET, there is support for [IEnumerable&lt;T&gt;](/dotnet/api/system.collections.generic.ienumerable-1?view=dotnet-uwp-10.0&preserve-view=true).
+IVector inherits [IIterable](iiterable_1.md). Types that implement IVector also implement the interface members of [IIterable](iiterable_1.md). Similarly, if you're using .NET, there is support for [IEnumerable\<T\>](/dotnet/api/system.collections.generic.ienumerable-1).
 
 ## -examples
 
 ## -see-also
 
-[Collections (C++/CX)](/cpp/cppcx/collections-c-cx), [System.Collections.Generic.IList<T>](/dotnet/api/system.collections.generic.ilist-1?view=dotnet-uwp-10.0&preserve-view=true)
+[Collections (C++/CX)](/cpp/cppcx/collections-c-cx), [System.Collections.Generic.IList\<T\>](/dotnet/api/system.collections.generic.ilist-1)

--- a/windows.foundation.collections/ivector_1.md
+++ b/windows.foundation.collections/ivector_1.md
@@ -41,11 +41,7 @@ Returns an iterator to one past the last element of the collection, for use in C
 
 ### Interface inheritance
 
-<<<<<<< HEAD
-IVector inherits [IIterable](iiterable_1.md). Types that implement IVector also implement the interface members of [IIterable](iiterable_1.md). Similarly, if you're using .NET, there is support for [IEnumerable\<T\>](/dotnet/api/system.collections.generic.ienumerable-1).
-=======
 IVector inherits [IIterable](iiterable_1.md). Types that implement IVector also implement the interface members of [IIterable](iiterable_1.md). Similarly, if you're using .NET, there is support for [IEnumerable&lt;T&gt;](/dotnet/api/system.collections.generic.ienumerable-1?view=dotnet-uwp-10.0&preserve-view=true).
->>>>>>> cd84458f70e29e2fa6b720ec78056581fa3bce0b
 
 ## -examples
 


### PR DESCRIPTION
This PR fixes a few conflicts on the "Interface inheritance" and "See also" sections on the IVector<T> documentation.