### PR TITLE
Remove unneeded usage note

### DIFF
--- a/windows.ui.input.inking/inkpresenter.md
+++ b/windows.ui.input.inking/inkpresenter.md
@@ -11,8 +11,6 @@ public class InkPresenter : Windows.UI.Input.Inking.IInkPresenter, Windows.UI.In
 # Windows.UI.Input.Inking.InkPresenter
 
 ## -description
-> [!NOTE]
-> For Universal Windows app using Extensible Application Markup Language (XAML), we recommend using InkPresenter and the [InkCanvas](../windows.ui.xaml.controls/inkcanvas.md) control instead of [InkManager](inkmanager.md).
 
 Provides properties, methods, and events for managing the input, processing, and rendering of ink input (standard and modified) for an [InkCanvas](../windows.ui.xaml.controls/inkcanvas.md) control.
 

--- a/windows.ui.input.inking/inkpresenter.md
+++ b/windows.ui.input.inking/inkpresenter.md
@@ -14,6 +14,12 @@ public class InkPresenter : Windows.UI.Input.Inking.IInkPresenter, Windows.UI.In
 
 Provides properties, methods, and events for managing the input, processing, and rendering of ink input (standard and modified) for an [InkCanvas](../windows.ui.xaml.controls/inkcanvas.md) control.
 
+## -remarks
+
+For Universal Windows apps, we recommend using InkPresenter and the [InkCanvas](../windows.ui.xaml.controls/inkcanvas.md) control instead of [InkManager](inkmanager.md).
+
+The InkPresenter class cannot be instantiated directly. It is returned as a property of an [InkCanvas](../windows.ui.xaml.controls/inkcanvas.md) object.
+
 > [!NOTE]
 > Standard ink input (pen tip or eraser tip/button) is not modified with a secondary affordance, such as a pen barrel button, right mouse button, or similar (see [RightDragAction](inkinputprocessingconfiguration_rightdragaction.md)).
 
@@ -26,9 +32,6 @@ All input can be passed through to your app for processing by setting [InkInputP
 Leaving input unprocessed by the [InkPresenter](inkunprocessedinput_inkpresenter.md) lets you support a customized ink experience and extended functionality such as selection.
 
 For complete control of ink input and to render it to the Direct2D device context of your Universal Windows app, instead of the default [InkCanvas](../windows.ui.xaml.controls/inkcanvas.md) control, call [ActivateCustomDrying](inkpresenter_activatecustomdrying_1826048524.md) prior to loading the [InkCanvas](../windows.ui.xaml.controls/inkcanvas.md). This requires an [IInkD2DRenderer](/windows/desktop/api/inkrenderer/nn-inkrenderer-iinkd2drenderer) object to manage the ink input (see the [Complex ink sample](https://github.com/Microsoft/Windows-universal-samples/tree/master/Samples/ComplexInk)).
-
-## -remarks
-The InkPresenter class cannot be instantiated directly. It is returned as a property of an [InkCanvas](../windows.ui.xaml.controls/inkcanvas.md) object.
 
 ### Version history
 


### PR DESCRIPTION
The note directs the reader to use `InkPresenter` instead of `InkManager`, even though they are already on the page for `InkPresenter`.