### PR TITLE
Update MemoryBuffer to relate to IMemoryBufferByteAccess

### DIFF
--- a/windows.foundation/memorybuffer.md
+++ b/windows.foundation/memorybuffer.md
@@ -14,10 +14,10 @@ Represents a reference counted memory buffer.
 
 ## -remarks
 
-This type also implements the COM interface [**IMemoryBufferByteAccess**](/windows/win32/winrt/imemorybufferbyteaccess-getbuffer) which provides direct access to the buffer's storage. See the [Custom Effect sample](https://github.com/microsoft/Windows-universal-samples/blob/main/Samples/AudioCreation/cs/CustomEffect/CustomEffect.cs) for an example of accessing the buffer from C#.
+This type also implements the COM interface [**IMemoryBufferByteAccess**](/windows/win32/winrt/imemorybufferbyteaccess-getbuffer), which provides direct access to the buffer's storage. See the [Custom Effect sample](https://github.com/microsoft/Windows-universal-samples/blob/main/Samples/AudioCreation/cs/CustomEffect/CustomEffect.cs) for a C# example on how to access the buffer.
 
 > [!NOTE]
-> C++/WinRT provides extension methods on `MemoryBuffer` to access the data directly. Different languages and runtimes have varying ways to access process memory. Use care when accessing the buffer, as the lifecycle of the memory is related to the lifecycle of the `IMemoryBufferByteAccess` interface from whence it came.
+> C++/WinRT provides extension methods on `MemoryBuffer` to access the data directly. Various languages and runtimes provide unique ways to access process memory. Be careful when accessing the buffer as the lifecycle of the memory is related to the lifecycle of the `IMemoryBufferByteAccess` interface.
 
 ## -examples
 

--- a/windows.foundation/memorybuffer.md
+++ b/windows.foundation/memorybuffer.md
@@ -14,7 +14,12 @@ Represents a reference counted memory buffer.
 
 ## -remarks
 
+This type also implements the COM interface [**IMemoryBufferByteAccess**](/windows/win32/winrt/imemorybufferbyteaccess-getbuffer) which provides direct access to the buffer's storage. See the [Custom Effect sample](https://github.com/microsoft/Windows-universal-samples/blob/main/Samples/AudioCreation/cs/CustomEffect/CustomEffect.cs) for an example of accessing the buffer from C#.
+
+> [!NOTE]
+> C++/WinRT provides extension methods on `MemoryBuffer` to access the data directly. Different languages and runtimes have varying ways to access process memory. Use care when accessing the buffer, as the lifecycle of the memory is related to the lifecycle of the `IMemoryBufferByteAccess` interface from whence it came.
+
 ## -examples
 
 ## -see-also
-[IMemoryBuffer](imemorybuffer.md), [IClosable](iclosable.md)
+[IMemoryBuffer](imemorybuffer.md), [IClosable](iclosable.md), [IMemoryBufferByteAccess](/windows/win32/winrt/imemorybufferbyteaccess-getbuffer)


### PR DESCRIPTION
See also https://github.com/microsoft/CsWinRT/issues/1214 - customer request for clarification about how to get from a `MemoryBuffer` to the underlying bytes.