### PR TITLE
Update storagefilequeryresult_getfilesasync_1261374131.md

### DIFF
--- a/windows.storage.search/storagefilequeryresult_getfilesasync_1261374131.md
+++ b/windows.storage.search/storagefilequeryresult_getfilesasync_1261374131.md
@@ -17,7 +17,7 @@ Retrieves a list of files in a specified range.
 The zero-based index of the first file to retrieve. This parameter is 0 by default.
 
 ### -param maxNumberOfItems
-The maximum number of files to retrieve. Use -1 to retrieve all files. If the range contains fewer files than the max number, all files in the range are returned.
+The maximum number of files to retrieve. Use the max value of `UInt32` (e.g. `uint.MaxValue` in C#, `std::numeric_limits<uint32_t>::max()` in C++. Some code in C++ use `-1` if implicit conversion is allowed) to retrieve all files. If the range contains fewer files than the max number, all files in the range are returned.
 
 ## -returns
 When this method completes successfully, it returns a list (type [IVectorView](../windows.foundation.collections/ivectorview_1.md)) of files that are represented by [StorageFile](../windows.storage/storagefile.md) objects.

--- a/windows.storage.search/storagefilequeryresult_getfilesasync_1261374131.md
+++ b/windows.storage.search/storagefilequeryresult_getfilesasync_1261374131.md
@@ -17,7 +17,7 @@ Retrieves a list of files in a specified range.
 The zero-based index of the first file to retrieve. This parameter is 0 by default.
 
 ### -param maxNumberOfItems
-The maximum number of files to retrieve. Use the max value of `UInt32` (e.g. `uint.MaxValue` in C#, `std::numeric_limits<uint32_t>::max()` in C++. Some code in C++ use `-1` if implicit conversion is allowed) to retrieve all files. If the range contains fewer files than the max number, all files in the range are returned.
+The maximum number of files to retrieve. Use the max value of `UInt32` (e.g. `uint.MaxValue` in C#, `std::numeric_limits<uint32_t>::max()` in C++. Some code in C++ may use `-1` if implicit conversion is allowed) to retrieve all files. If the range contains fewer files than the max number, all files in the range are returned.
 
 ## -returns
 When this method completes successfully, it returns a list (type [IVectorView](../windows.foundation.collections/ivectorview_1.md)) of files that are represented by [StorageFile](../windows.storage/storagefile.md) objects.


### PR DESCRIPTION
The type of `maxNumberOfItems`, `UInt32`, and the documented value to use, `-1`, while make sense at the ABI level, doesn't make sense at the API level.

This PR fixes that by documenting the binary equivalent of -1, max value of `UInt32`, while providing samples in common supported languages. The old documented value `-1` is also kept, but the doc explicitly says it works only because of implicit conversion.