### PR TITLE
Fix typo on Treeview.HasUnrealizedChildren property

### DIFF
--- a/windows.ui.xaml.controls/treeviewnode_hasunrealizedchildren.md
+++ b/windows.ui.xaml.controls/treeviewnode_hasunrealizedchildren.md
@@ -15,7 +15,7 @@ Gets or sets a value that indicates whether the current node has child items tha
 
 ## -property-value
 
-**true** if the current node has child items that haven't been shown; otherwise, **false**.
+**true** of the current node has child items that haven't been shown; otherwise, **false**.
 
 ## -remarks
 

--- a/windows.ui.xaml.controls/treeviewnode_hasunrealizedchildren.md
+++ b/windows.ui.xaml.controls/treeviewnode_hasunrealizedchildren.md
@@ -15,7 +15,7 @@ Gets or sets a value that indicates whether the current node has child items tha
 
 ## -property-value
 
-**true** of the current node has child items that haven't been shown; otherwise, **false**.
+**true** if the current node has child items that haven't been shown; otherwise, **false**.
 
 ## -remarks
 


### PR DESCRIPTION
Fixes typo for the UWP of the Treeview.HasUnrealizedChildren property.