### PR TITLE
Add a missing '>' in TextBlock.Inlines syntax

### DIFF
--- a/windows.ui.xaml.controls/textblock_inlines.md
+++ b/windows.ui.xaml.controls/textblock_inlines.md
@@ -16,7 +16,7 @@ Gets the collection of inline text elements within a [TextBlock](textblock.md).
 
 ## -xaml-syntax
 ```xaml
-<TextBlock
+<TextBlock>
   oneOrMoreInlineElements
 </TextBlock>
 ```


### PR DESCRIPTION
This pull request is to add a missing '>' character in the syntax section of `TextBlock.Inlines` property page.