### PR TITLE
Add a note that "Copy link" is not a share for DataPackage

### DIFF
--- a/windows.applicationmodel.datatransfer/datapackage_sharecompleted.md
+++ b/windows.applicationmodel.datatransfer/datapackage_sharecompleted.md
@@ -13,7 +13,8 @@ public event TypedEventHandler ShareCompleted<DataPackage, ShareCompletedEventAr
 An event that is triggered when a share is completed. Shares can be sent to an app, a provider, or a contact.
 
 ## -remarks
-Note that selecting "Copy link" does not count as a share and thus does not fire this event, nor ShareCanceled.
+> [!NOTE]
+> Selecting "Copy link" is not considered a *share* and thus does not fire this event, nor `ShareCanceled`.
 
 ## -see-also
 

--- a/windows.applicationmodel.datatransfer/datapackage_sharecompleted.md
+++ b/windows.applicationmodel.datatransfer/datapackage_sharecompleted.md
@@ -13,6 +13,7 @@ public event TypedEventHandler ShareCompleted<DataPackage, ShareCompletedEventAr
 An event that is triggered when a share is completed. Shares can be sent to an app, a provider, or a contact.
 
 ## -remarks
+Note that selecting "Copy link" does not count as a share and thus does not fire this event, nor ShareCanceled.
 
 ## -see-also
 


### PR DESCRIPTION
I tried to ping some Microsoft people to fix this, but as of Windows 11 22623.1245 this is still the behavior.

Some history:
* https://github.com/w3c/web-share/issues/188
* https://bugs.chromium.org/p/chromium/issues/detail?id=1107660
* https://phabricator.services.mozilla.com/D121421

You can check this behavior on Firefox by enabling `widget.windows.share.wait_action.enabled` and selecting "Copy link" in the share dialog from https://web-share.glitch.me.