### PR TITLE
Add `using` at `SerialDevice.FromIdAsync()`

### DIFF
--- a/windows.devices.serialcommunication/serialdevice_getdeviceselectorfromusbvidpid_2128196110.md
+++ b/windows.devices.serialcommunication/serialdevice_getdeviceselectorfromusbvidpid_2128196110.md
@@ -45,7 +45,7 @@ protected override async void OnLaunched1(LaunchActivatedEventArgs args)
         return;
     }
 
-    SerialDevice device = await SerialDevice.FromIdAsync(myDevices[0].Id);
+    using SerialDevice device = await SerialDevice.FromIdAsync(myDevices[0].Id);
 
 }
 


### PR DESCRIPTION
Resolved the problem of returning `null` when calling the `OnLaunched1()` method more than once.