### PR TITLE
Fix the parameter type for GetDateTimeArray

### DIFF
--- a/windows.foundation/ipropertyvalue_getdatetimearray_1161464137.md
+++ b/windows.foundation/ipropertyvalue_getdatetimearray_1161464137.md
@@ -1,10 +1,10 @@
 ---
--api-id: M:Windows.Foundation.IPropertyValue.GetDateTimeArray(Windows.Foundation.DateTime[]@)
+-api-id: M:Windows.Foundation.IPropertyValue.GetDateTimeArray(Windows.Foundation.DateTimeOffset[]@)
 -api-type: winrt method
 ---
 
 <!-- Method syntax
-public void GetDateTimeArray(Windows.Foundation.DateTime[] value)
+public void GetDateTimeArray(Windows.Foundation.DateTimeOffset[] value)
 -->
 
 # Windows.Foundation.IPropertyValue.GetDateTimeArray


### PR DESCRIPTION
The type for `GetDateTimeArray` is actually `DateTimeOffset`, not `DateTime` (same as `GetDateTime` returns `DateTimeOffset`)