### PR TITLE
Corrections to RectHelper and SizeHelper's definition of "empty"

### DIFF
--- a/windows.ui.xaml/recthelper_empty.md
+++ b/windows.ui.xaml/recthelper_empty.md
@@ -11,13 +11,13 @@ public Windows.Foundation.Rect Empty { get; }
 
 ## -description
 
-Gets a static [Rect](../windows.foundation/rect.md) value where the [Rect](../windows.foundation/rect.md) has no size or position (all values 0). C# and Microsoft Visual Basic code should use [Rect.Empty](/dotnet/api/windows.foundation.rect.empty?view=dotnet-uwp-10.0&preserve-view=true) instead.
+Gets a static [Rect](../windows.foundation/rect.md) value where the [Rect](../windows.foundation/rect.md) has no size or position (width and height less than 0). C# and Microsoft Visual Basic code should use [Rect.Empty](/dotnet/api/windows.foundation.rect.empty?view=dotnet-uwp-10.0&preserve-view=true) instead.
 
 
 
 ## -property-value
 
-A [Rect](../windows.foundation/rect.md) with all values as 0.
+A [Rect](../windows.foundation/rect.md) with width and height less than 0.
 
 ## -remarks
 

--- a/windows.ui.xaml/recthelper_empty.md
+++ b/windows.ui.xaml/recthelper_empty.md
@@ -11,13 +11,13 @@ public Windows.Foundation.Rect Empty { get; }
 
 ## -description
 
-Gets a static [Rect](../windows.foundation/rect.md) value where the [Rect](../windows.foundation/rect.md) has no size or position (width and height less than 0). C# and Microsoft Visual Basic code should use [Rect.Empty](/dotnet/api/windows.foundation.rect.empty?view=dotnet-uwp-10.0&preserve-view=true) instead.
+Gets a static [Rect](../windows.foundation/rect.md) value where the [Rect](../windows.foundation/rect.md) has no size or position. C# and Microsoft Visual Basic code should use [Rect.Empty](/dotnet/api/windows.foundation.rect.empty?view=dotnet-uwp-10.0&preserve-view=true) instead.
 
 
 
 ## -property-value
 
-A [Rect](../windows.foundation/rect.md) with width and height less than 0.
+A [Rect](../windows.foundation/rect.md) with X and Y set to positive infinity, and Width and Height set to negative infinity.
 
 ## -remarks
 

--- a/windows.ui.xaml/recthelper_getbottom_1066401735.md
+++ b/windows.ui.xaml/recthelper_getbottom_1066401735.md
@@ -11,7 +11,7 @@ public float GetBottom(Windows.Foundation.Rect target)
 
 ## -description
 
-Gets a "Bottom" value for the specified [Rect](../windows.foundation/rect.md). So long as **Width** is positive, "Bottom" is evaluated as **Y** + **Height**. C# and Microsoft Visual Basic code should use [Rect.Bottom](/dotnet/api/windows.foundation.rect.bottom?view=dotnet-uwp-10.0&preserve-view=true) instead.
+Gets a "Bottom" value for the specified [Rect](../windows.foundation/rect.md). So long as the Rect is not the [Empty](recthelper_empty.md) Rect, "Bottom" is evaluated as **Y** + **Height**. C# and Microsoft Visual Basic code should use [Rect.Bottom](/dotnet/api/windows.foundation.rect.bottom?view=dotnet-uwp-10.0&preserve-view=true) instead.
 
 
 

--- a/windows.ui.xaml/recthelper_getbottom_1066401735.md
+++ b/windows.ui.xaml/recthelper_getbottom_1066401735.md
@@ -11,7 +11,7 @@ public float GetBottom(Windows.Foundation.Rect target)
 
 ## -description
 
-Gets a "Bottom" value for the specified [Rect](../windows.foundation/rect.md). So long as **Height** is positive, "Bottom" is evaluated as **Y** + **Height**. C# and Microsoft Visual Basic code should use [Rect.Bottom](/dotnet/api/windows.foundation.rect.bottom?view=dotnet-uwp-10.0&preserve-view=true) instead.
+Gets a "Bottom" value for the specified [Rect](../windows.foundation/rect.md). So long as **Width** is positive, "Bottom" is evaluated as **Y** + **Height**. C# and Microsoft Visual Basic code should use [Rect.Bottom](/dotnet/api/windows.foundation.rect.bottom?view=dotnet-uwp-10.0&preserve-view=true) instead.
 
 
 

--- a/windows.ui.xaml/recthelper_getisempty_1110221055.md
+++ b/windows.ui.xaml/recthelper_getisempty_1110221055.md
@@ -27,7 +27,7 @@ The [Rect](../windows.foundation/rect.md) to evaluate.
 
 ## -remarks
 
-Do not use this property to test for zero area; a rectangle with zero area is not necessarily the [Empty](recthelper_empty.md) rectangle. For more information, see the [Empty](recthelper_empty.md) property.
+Do not use this method to test for zero area; a rectangle with zero area is not necessarily the [Empty](recthelper_empty.md) rectangle. For more information, see the [Empty](recthelper_empty.md) property.
 
 ## -examples
 

--- a/windows.ui.xaml/recthelper_getisempty_1110221055.md
+++ b/windows.ui.xaml/recthelper_getisempty_1110221055.md
@@ -27,7 +27,7 @@ The [Rect](../windows.foundation/rect.md) to evaluate.
 
 ## -remarks
 
-GetIsEmpty will return **false** if the Rect has a width or height of 0. To check whether the size has a nonzero area, inspect Rect.Width and Rect.Height directly instead of calling this method.
+Do not use this property to test for zero area; a rectangle with zero area is not necessarily the [Empty](recthelper_empty.md) rectangle. For more information, see the [Empty](recthelper_empty.md) property.
 
 ## -examples
 

--- a/windows.ui.xaml/recthelper_getisempty_1110221055.md
+++ b/windows.ui.xaml/recthelper_getisempty_1110221055.md
@@ -27,6 +27,8 @@ The [Rect](../windows.foundation/rect.md) to evaluate.
 
 ## -remarks
 
+GetIsEmpty will return **false** if the Rect has a width or height of 0. To check whether the size has a nonzero area, inspect Rect.Width and Rect.Height directly instead of calling this method.
+
 ## -examples
 
 ## -see-also

--- a/windows.ui.xaml/recthelper_getleft_1023490401.md
+++ b/windows.ui.xaml/recthelper_getleft_1023490401.md
@@ -11,7 +11,7 @@ public float GetLeft(Windows.Foundation.Rect target)
 
 ## -description
 
-Gets a "Left" value for the specified [Rect](../windows.foundation/rect.md). So long as **Width** is positive, "Left" is evaluated as **X**. C# and Microsoft Visual Basic code should use [Rect.Left](/dotnet/api/windows.foundation.rect.left?view=dotnet-uwp-10.0&preserve-view=true) instead.
+Gets a "Left" value for the specified [Rect](../windows.foundation/rect.md). So long as the Rect is not the [Empty](recthelper_empty.md) Rect, "Left" is evaluated as **X**. C# and Microsoft Visual Basic code should use [Rect.Left](/dotnet/api/windows.foundation.rect.left?view=dotnet-uwp-10.0&preserve-view=true) instead.
 
 
 

--- a/windows.ui.xaml/recthelper_getright_1384154527.md
+++ b/windows.ui.xaml/recthelper_getright_1384154527.md
@@ -11,7 +11,7 @@ public float GetRight(Windows.Foundation.Rect target)
 
 ## -description
 
-Gets a "Right" value for the specified [Rect](../windows.foundation/rect.md). So long as **Width** is positive, "Right" is evaluated as **X** + **Width**. C# and Microsoft Visual Basic code should use [Rect.Right](/dotnet/api/windows.foundation.rect.right?view=dotnet-uwp-10.0&preserve-view=true) instead.
+Gets a "Right" value for the specified [Rect](../windows.foundation/rect.md). So long as the Rect is not the [Empty](recthelper_empty.md) Rect, "Right" is evaluated as **X** + **Width**. C# and Microsoft Visual Basic code should use [Rect.Right](/dotnet/api/windows.foundation.rect.right?view=dotnet-uwp-10.0&preserve-view=true) instead.
 
 
 

--- a/windows.ui.xaml/recthelper_gettop_1602274045.md
+++ b/windows.ui.xaml/recthelper_gettop_1602274045.md
@@ -11,7 +11,7 @@ public float GetTop(Windows.Foundation.Rect target)
 
 ## -description
 
-Gets a "Top" value for the specified [Rect](../windows.foundation/rect.md). So long as **Height** is positive, "Top" is evaluated as **Y**. C# and Microsoft Visual Basic code should use [Rect.Top](/dotnet/api/windows.foundation.rect.top?view=dotnet-uwp-10.0&preserve-view=true) instead.
+Gets a "Top" value for the specified [Rect](../windows.foundation/rect.md). So long as **Width** is positive, "Top" is evaluated as **Y**. C# and Microsoft Visual Basic code should use [Rect.Top](/dotnet/api/windows.foundation.rect.top?view=dotnet-uwp-10.0&preserve-view=true) instead.
 
 
 

--- a/windows.ui.xaml/recthelper_gettop_1602274045.md
+++ b/windows.ui.xaml/recthelper_gettop_1602274045.md
@@ -11,7 +11,7 @@ public float GetTop(Windows.Foundation.Rect target)
 
 ## -description
 
-Gets a "Top" value for the specified [Rect](../windows.foundation/rect.md). So long as **Width** is positive, "Top" is evaluated as **Y**. C# and Microsoft Visual Basic code should use [Rect.Top](/dotnet/api/windows.foundation.rect.top?view=dotnet-uwp-10.0&preserve-view=true) instead.
+Gets a "Top" value for the specified [Rect](../windows.foundation/rect.md). So long as the Rect is not the [Empty](recthelper_empty.md) Rect, "Top" is evaluated as **Y**. C# and Microsoft Visual Basic code should use [Rect.Top](/dotnet/api/windows.foundation.rect.top?view=dotnet-uwp-10.0&preserve-view=true) instead.
 
 
 

--- a/windows.ui.xaml/sizehelper_empty.md
+++ b/windows.ui.xaml/sizehelper_empty.md
@@ -11,13 +11,13 @@ public Windows.Foundation.Size Empty { get; }
 
 ## -description
 
-Gets a static [Size](../windows.foundation/size.md) value where the [Size](../windows.foundation/size.md) has no height or width (width and height less than 0). C# and Microsoft Visual Basic code should use [Size.Empty](/dotnet/api/windows.foundation.size.empty?view=dotnet-uwp-10.0&preserve-view=true) instead.
+Gets a static [Size](../windows.foundation/size.md) value where the [Size](../windows.foundation/size.md) has no height or width. C# and Microsoft Visual Basic code should use [Size.Empty](/dotnet/api/windows.foundation.size.empty?view=dotnet-uwp-10.0&preserve-view=true) instead.
 
 
 
 ## -property-value
 
-A [Size](../windows.foundation/size.md) with with and height less than 0.
+A [Size](../windows.foundation/size.md) with Width and Height set to negative infinity.
 
 ## -remarks
 

--- a/windows.ui.xaml/sizehelper_empty.md
+++ b/windows.ui.xaml/sizehelper_empty.md
@@ -11,13 +11,13 @@ public Windows.Foundation.Size Empty { get; }
 
 ## -description
 
-Gets a static [Size](../windows.foundation/size.md) value where the [Size](../windows.foundation/size.md) has no height or width (all values 0). C# and Microsoft Visual Basic code should use [Size.Empty](/dotnet/api/windows.foundation.size.empty?view=dotnet-uwp-10.0&preserve-view=true) instead.
+Gets a static [Size](../windows.foundation/size.md) value where the [Size](../windows.foundation/size.md) has no height or width (width and height less than 0). C# and Microsoft Visual Basic code should use [Size.Empty](/dotnet/api/windows.foundation.size.empty?view=dotnet-uwp-10.0&preserve-view=true) instead.
 
 
 
 ## -property-value
 
-A [Size](../windows.foundation/size.md) with all values as 0.
+A [Size](../windows.foundation/size.md) with with and height less than 0.
 
 ## -remarks
 

--- a/windows.ui.xaml/sizehelper_getisempty_1023510010.md
+++ b/windows.ui.xaml/sizehelper_getisempty_1023510010.md
@@ -27,6 +27,8 @@ The [Size](../windows.foundation/size.md) to evaluate.
 
 ## -remarks
 
+GetIsEmpty will return **false** if the Size has a width or height of 0. To check whether the size has a nonzero area, inspect Size.Width and Size.Height directly instead of calling this method.
+
 ## -examples
 
 ## -see-also

--- a/windows.ui.xaml/sizehelper_getisempty_1023510010.md
+++ b/windows.ui.xaml/sizehelper_getisempty_1023510010.md
@@ -27,7 +27,7 @@ The [Size](../windows.foundation/size.md) to evaluate.
 
 ## -remarks
 
-Do not use this property to test for zero area; a size with zero area is not necessarily the [Empty](sizehelper_empty.md) size. For more information, see the [Empty](sizehelper_empty.md) property.
+Do not use this method to test for zero area; a size with zero area is not necessarily the [Empty](sizehelper_empty.md) size. For more information, see the [Empty](sizehelper_empty.md) property.
 
 ## -examples
 

--- a/windows.ui.xaml/sizehelper_getisempty_1023510010.md
+++ b/windows.ui.xaml/sizehelper_getisempty_1023510010.md
@@ -27,7 +27,7 @@ The [Size](../windows.foundation/size.md) to evaluate.
 
 ## -remarks
 
-GetIsEmpty will return **false** if the Size has a width or height of 0. To check whether the size has a nonzero area, inspect Size.Width and Size.Height directly instead of calling this method.
+Do not use this property to test for zero area; a size with zero area is not necessarily the [Empty](sizehelper_empty.md) size. For more information, see the [Empty](sizehelper_empty.md) property.
 
 ## -examples
 


### PR DESCRIPTION
RectHelper and SizeHelper use a definition of "Empty" which matches .NET's [System.Windows.Rect.Empty](https://learn.microsoft.com/en-us/dotnet/api/system.windows.rect.empty). A Rect or Size with Width == 0 or Height == 0 is not "empty" because it is not _the_ Empty value.

- RectHelper.Empty and SizeHelper.Empty actually return structs where the Width and Height are initialized to _negative infinity_, not 0.
- For GetLeft/GetTop/GetRight/GetBottom, the implementation actually calls GetIsEmpty rather than checking for positive Width or Height.
- In the Remarks section for RectHelper.GetIsEmpty and SizeHelper.GetIsEmpty, add the same caveat that is in the [.NET docs](https://learn.microsoft.com/en-us/dotnet/api/system.windows.rect.isempty): "this method should not be used to check for zero area".

Note that this information also applies to the Microsoft.UI.Xaml version of these methods. I assume I'll need to open a separate PR against winapps-winrt-api for that; please let me know if there's a different process which is preferred.