### PR TITLE
Fix the typo in UIElement.IsTapEnabled XAML syntax

### DIFF
--- a/windows.ui.xaml/uielement_istapenabled.md
+++ b/windows.ui.xaml/uielement_istapenabled.md
@@ -16,7 +16,7 @@ Gets or sets a value that determines whether the [Tapped](uielement_tapped.md) e
 
 ## -xaml-syntax
 ```xaml
-<uiElementIsTapEnabled="bool" />
+<uiElement IsTapEnabled="bool" />
 ```
 
 


### PR DESCRIPTION
XAML syntax sample is invalid