### PR TITLE
Update calendar_languages.md

### DIFF
--- a/windows.globalization/calendar_languages.md
+++ b/windows.globalization/calendar_languages.md
@@ -15,7 +15,7 @@ Gets the priority list of language identifiers that is used when formatting comp
 ## -property-value
 The list of language identifiers.
 
-**Starting in :** Language tags can support Unicode extensions. See the Remarks for the [Calendar(IIterable(String))](calendar_calendar_1181929246.md) constructor.
+Language tags can support Unicode extensions. See the Remarks for the [Calendar(IIterable(String))](calendar_calendar_1181929246.md) constructor.
 
 ## -remarks
 


### PR DESCRIPTION
Deleted **`Starting in : `** in [Property Value](https://learn.microsoft.com/en-us/uwp/api/windows.globalization.calendar.languages?view=winrt-22621#property-value) section.
