### PR TITLE
Update characterreceivedeventargs_keycode.md

### DIFF
--- a/windows.ui.core/characterreceivedeventargs_keycode.md
+++ b/windows.ui.core/characterreceivedeventargs_keycode.md
@@ -13,7 +13,7 @@ public uint KeyCode { get; }
 Gets the key code of the character received by the input queue.
 
 ## -property-value
-The character in UTF-16 encoding. Each supplementary character consist of a [surrogate pair](/windows/win32/intl/surrogates-and-supplementary-characters) sent as two separate events.
+The character in UTF-16 encoding. Each supplementary character consists of a [surrogate pair](/windows/win32/intl/surrogates-and-supplementary-characters) sent as two separate events.
 
 ## -remarks
 > **Windows 10**

--- a/windows.ui.core/characterreceivedeventargs_keycode.md
+++ b/windows.ui.core/characterreceivedeventargs_keycode.md
@@ -13,11 +13,11 @@ public uint KeyCode { get; }
 Gets the key code of the character received by the input queue.
 
 ## -property-value
-The character in UTF-32 encoding.
+The character in UTF-16 encoding. Each supplementary character consist of a [surrogate pair](/windows/win32/intl/surrogates-and-supplementary-characters) sent as two separate events.
 
 ## -remarks
 > **Windows 10**
-> Apps do not receive this event when an [Input Method Editor (IME)](/previous-versions/windows/apps/hh967427(v=win.10)) is enabled. The Input Method Editor (IME) handles all keyboard input and sets [Handled](characterreceivedeventargs_handled.md) to **true**.
+> Apps do not receive this event when an [Input Method Editor (IME)](/windows/apps/design/input/input-method-editors) is enabled. The Input Method Editor (IME) handles all keyboard input and sets [Handled](characterreceivedeventargs_handled.md) to **true**.
 
 > **Windows Phone**
 > This API is supported in native apps only.


### PR DESCRIPTION
Fix character encoding in `CharacterReceivedEventArgs`. It is actually UTF-16 with high/low surrogates. I have checked this in debugger with [Gothic keyboard layout](https://learn.microsoft.com/en-us/globalization/keyboards/kbdgthc) that produce characters outside BMP.