### PR TITLE
Document exception if surface creation fails due to unsupported pixel format

### DIFF
--- a/windows.ui.composition/compositiongraphicsdevice_createdrawingsurface2_1137892861.md
+++ b/windows.ui.composition/compositiongraphicsdevice_createdrawingsurface2_1137892861.md
@@ -29,6 +29,7 @@ The alpha mode of the drawing surface.
 Returns the created CompositionDrawingSurface.
 
 ## -remarks
+If the requested pixel format is unsupported by the graphics device, an exception will be thrown.
 
 ## -see-also
 

--- a/windows.ui.composition/compositiongraphicsdevice_createdrawingsurface_428570653.md
+++ b/windows.ui.composition/compositiongraphicsdevice_createdrawingsurface_428570653.md
@@ -28,6 +28,7 @@ How the alpha channel should be handled.
 The created [CompositionDrawingSurface](compositiondrawingsurface.md).
 
 ## -remarks
+If the requested pixel format is unsupported by the graphics device, an exception will be thrown.
 
 ## -examples
 


### PR DESCRIPTION
I added a remark stating that an exception will be thrown if the pixel format is unsupported.

Some pixel formats are optional under WDDM. If it's not supported by the adapter the call will return `DXGI_ERROR_UNSUPPORTED`.

Developers should consider handling this when requesting pixel formats other than `DXGI_FORMAT_B8G8R8A8_UNORM`, e.g., `A8UIntNormalized`.

Same applies to these:
https://github.com/MicrosoftDocs/winrt-api/blob/50ceac2e1fc7058c563be32140f4b38fb2fc4164/windows.ui.composition/compositiongraphicsdevice_createdrawingsurface_428570653.md
https://github.com/MicrosoftDocs/winrt-api/blob/50ceac2e1fc7058c563be32140f4b38fb2fc4164/windows.ui.composition/compositiongraphicsdevice_createdrawingsurface2_1137892861.md