### PR TITLE
[GetKeyState] Add a reference to the WinUI replacement for CoreWindow.GetKeyState

### DIFF
--- a/windows.ui.core/corewindow_getkeystate_1676715341.md
+++ b/windows.ui.core/corewindow_getkeystate_1676715341.md
@@ -20,12 +20,13 @@ The virtual key for which state is returned.
 The flags indicating the current state of the supplied virtual key when the input event fired.
 
 > [!NOTE]
-> All keys support the **Locked** state (not just the standard Caps Lock and Num Lock keys).
-
-> [!NOTE]
-> For WinUI 3 apps, this method will return null. Use [**InputKeyboardSource.GetKeyStateForCurrentThread**](/windows/windows-app-sdk/api/winrt/microsoft.ui.input.inputkeyboardsource.getkeystateforcurrentthread) instead. See [Windows Runtime APIs not supported in desktop apps](/windows/apps/desktop/modernize/desktop-to-uwp-supported-api).
+> For WinUI 3 apps, this method returns null. Use [**Microsoft.UI.Input.InputKeyboardSource.GetKeyStateForCurrentThread**](/windows/windows-app-sdk/api/winrt/microsoft.ui.input.inputkeyboardsource.getkeystateforcurrentthread) instead.
+>
+> See [Windows Runtime APIs not supported in desktop apps](/windows/apps/desktop/modernize/desktop-to-uwp-supported-api).
 
 ## -remarks
+
+All keys support the **Locked** state (not just the standard Caps Lock and Num Lock keys).
 
 ## -examples
 

--- a/windows.ui.core/corewindow_getkeystate_1676715341.md
+++ b/windows.ui.core/corewindow_getkeystate_1676715341.md
@@ -22,9 +22,15 @@ The flags indicating the current state of the supplied virtual key when the inpu
 > [!NOTE]
 > All keys support the **Locked** state (not just the standard Caps Lock and Num Lock keys).
 
+> [!NOTE]
+> For WinUI 3 apps, this method will return null. Use [**InputKeyboardSource.GetKeyStateForCurrentThread**](/windows/windows-app-sdk/api/winrt/microsoft.ui.input.inputkeyboardsource.getkeystateforcurrentthread) instead. See [Windows Runtime APIs not supported in desktop apps](/windows/apps/desktop/modernize/desktop-to-uwp-supported-api).
+
 ## -remarks
 
 ## -examples
 
 ## -see-also
-[CoreVirtualKeyStates](corevirtualkeystates.md), [GetAsyncKeyState](corewindow_getasynckeystate_1621551046.md)
+
+* [CoreVirtualKeyStates](corevirtualkeystates.md)
+* [GetAsyncKeyState](corewindow_getasynckeystate_1621551046.md)
+* [InputKeyboardSource.GetKeyStateForCurrentThread](/windows/windows-app-sdk/api/winrt/microsoft.ui.input.inputkeyboardsource.getkeystateforcurrentthread)


### PR DESCRIPTION
This change adds a reference to `InputKeyboardSource.GetCurrentKeyState` on the docs for `CoreWindow.GetKeyState`, since that API is not usable in WinUI 3.