### PR TITLE
Update UWP VPN docs with new mtu and maxFrameSize related guidance.

### DIFF
--- a/windows.networking.vpn/vpnchannel_start_1915696275.md
+++ b/windows.networking.vpn/vpnchannel_start_1915696275.md
@@ -29,10 +29,10 @@ A pointer to Windows.Networking.VpnRouteAssignment class that represents the rou
 A pointer to Windows.Networking.DomainNameAssignment class that represents the list of name prefixes that are associated to the VPN channel, including its DNS and proxy servers.
 
 ### -param mtuSize
-A UINT16 value specifying the MTU size of the VPN L3 network interface. This is also the size of the IVpnPacketBuffers in the Receive pool.
+A UINT16 value specifying the MTU size of the VPN L3 network interface. This is also the size of the IVpnPacketBuffers in the Receive pool. This value should be configured to be at most 1400.
 
 ### -param maxFrameSize
-A UINT16 value specifying the max size of the frame defined by the VPN protocol encapsulation without counting the *outerTunnelTransport*. This is also the size of the **IVpnPacketBuffers** in the Send pool.
+A UINT16 value specifying the max size of the frame defined by the VPN protocol encapsulation without counting the *outerTunnelTransport*. This is also the size of the **IVpnPacketBuffers** in the Send pool. This value should be configured as mtuSize + [size of encapsulation headers], and should be <=1500. If it would be greater than 1500, mtuSize should be adjusted accordingly.
 
 ### -param optimizeForLowCostNetwork
 A **Boolean** specifying whether the VPN framework should monitor and use low cost networks as they are available. If **TRUE** the VPN framework will invoke the connect() callback to the VPN plug-in to reconnect it whenever the old network was costed and a new low cost network becomes available.

--- a/windows.networking.vpn/vpnchannel_start_1915696275.md
+++ b/windows.networking.vpn/vpnchannel_start_1915696275.md
@@ -32,7 +32,7 @@ A pointer to Windows.Networking.DomainNameAssignment class that represents the l
 A UINT16 value specifying the MTU size of the VPN L3 network interface. This is also the size of the IVpnPacketBuffers in the Receive pool. This value should be configured to be at most 1400.
 
 ### -param maxFrameSize
-A UINT16 value specifying the max size of the frame defined by the VPN protocol encapsulation without counting the *outerTunnelTransport*. This is also the size of the **IVpnPacketBuffers** in the Send pool. This value should be configured as mtuSize + [size of encapsulation headers], and should be <=1500. If it would be greater than 1500, mtuSize should be adjusted accordingly.
+A UINT16 value specifying the max size of the frame defined by the VPN protocol encapsulation without counting the *outerTunnelTransport*. This is also the size of the **IVpnPacketBuffers** in the Send pool. This value should be configured as mtuSize + [size of encapsulation headers], and should be <=1500. If it would be greater than 1500 either mtuSize or encapsulation header size should be reduced as the platform limits the framesize to 1500.
 
 ### -param optimizeForLowCostNetwork
 A **Boolean** specifying whether the VPN framework should monitor and use low cost networks as they are available. If **TRUE** the VPN framework will invoke the connect() callback to the VPN plug-in to reconnect it whenever the old network was costed and a new low cost network becomes available.

--- a/windows.networking.vpn/vpnchannel_startexistingtransports_1445053041.md
+++ b/windows.networking.vpn/vpnchannel_startexistingtransports_1445053041.md
@@ -29,10 +29,10 @@ A pointer to a **Windows.Networking.VpnRouteAssignment** class that represents t
 A pointer to a **Windows.Networking.DomainNameAssignment** class that represents the list of name prefixes that are associated to the VPN channel, including its DNS and proxy servers.
 
 ### -param mtuSize
-A UINT16 value specifying the MTU size of the VPN L3 network interface. This is also the size of the **IVpnPacketBuffers** in the Receive pool.
+A UINT16 value specifying the MTU size of the VPN L3 network interface. This is also the size of the **IVpnPacketBuffers** in the Receive pool. This value should be configured to be at most 1400.
 
 ### -param maxFrameSize
-A UINT16 value specifying the max size of the frame defined by the VPN protocol encapsulation without counting the outerTunnelTransport. This is also the size of the **IVpnPacketBuffers** in the Send pool.
+A UINT16 value specifying the max size of the frame defined by the VPN protocol encapsulation without counting the outerTunnelTransport. This is also the size of the **IVpnPacketBuffers** in the Send pool. This value should be configured as mtuSize + [size of encapsulation headers], and should be <=1500. If it would be greater than 1500, mtuSize should be adjusted accordingly.
 
 ### -param Reserved
 Reserved.

--- a/windows.networking.vpn/vpnchannel_startexistingtransports_1445053041.md
+++ b/windows.networking.vpn/vpnchannel_startexistingtransports_1445053041.md
@@ -32,7 +32,7 @@ A pointer to a **Windows.Networking.DomainNameAssignment** class that represents
 A UINT16 value specifying the MTU size of the VPN L3 network interface. This is also the size of the **IVpnPacketBuffers** in the Receive pool. This value should be configured to be at most 1400.
 
 ### -param maxFrameSize
-A UINT16 value specifying the max size of the frame defined by the VPN protocol encapsulation without counting the outerTunnelTransport. This is also the size of the **IVpnPacketBuffers** in the Send pool. This value should be configured as mtuSize + [size of encapsulation headers], and should be <=1500. If it would be greater than 1500, mtuSize should be adjusted accordingly.
+A UINT16 value specifying the max size of the frame defined by the VPN protocol encapsulation without counting the outerTunnelTransport. This is also the size of the **IVpnPacketBuffers** in the Send pool. This value should be configured as mtuSize + [size of encapsulation headers], and should be <=1500. If it would be greater than 1500 either mtuSize or encapsulation header size should be reduced as the platform limits the framesize to 1500.
 
 ### -param Reserved
 Reserved.

--- a/windows.networking.vpn/vpnchannel_startwithmaintransport_826031841.md
+++ b/windows.networking.vpn/vpnchannel_startwithmaintransport_826031841.md
@@ -32,7 +32,7 @@ A pointer to a **Windows.Networking.DomainNameAssignment** class that represents
 A UINT16 value specifying the MTU size of the VPN L3 network interface. This is also the size of the **IVpnPacketBuffers** in the Receive pool. This value should be configured to be at most 1400.
 
 ### -param maxFrameSize
-A UINT16 value specifying the max size of the frame defined by the VPN protocol encapsulation without counting the outerTunnelTransport. This is also the size of the **IVpnPacketBuffers** in the Send pool. This value should be configured as mtuSize + [size of encapsulation headers], and should be <=1500. If it would be greater than 1500, mtuSize should be adjusted accordingly.
+A UINT16 value specifying the max size of the frame defined by the VPN protocol encapsulation without counting the outerTunnelTransport. This is also the size of the **IVpnPacketBuffers** in the Send pool. This value should be configured as mtuSize + [size of encapsulation headers], and should be <=1500. If it would be greater than 1500 either mtuSize or encapsulation header size should be reduced as the platform limits the framesize to 1500.
 
 ### -param Reserved
 Reserved

--- a/windows.networking.vpn/vpnchannel_startwithmaintransport_826031841.md
+++ b/windows.networking.vpn/vpnchannel_startwithmaintransport_826031841.md
@@ -29,10 +29,10 @@ A pointer to a **Windows.Networking.VpnRouteAssignment ** class that represents 
 A pointer to a **Windows.Networking.DomainNameAssignment** class that represents the list of name prefixes that are associated to the VPN channel, including its DNS and proxy servers.
 
 ### -param mtuSize
-A UINT16 value specifying the MTU size of the VPN L3 network interface. This is also the size of the **IVpnPacketBuffers** in the Receive pool.
+A UINT16 value specifying the MTU size of the VPN L3 network interface. This is also the size of the **IVpnPacketBuffers** in the Receive pool. This value should be configured to be at most 1400.
 
 ### -param maxFrameSize
-A UINT16 value specifying the max size of the frame defined by the VPN protocol encapsulation without counting the outerTunnelTransport. This is also the size of the **IVpnPacketBuffers** in the Send pool.
+A UINT16 value specifying the max size of the frame defined by the VPN protocol encapsulation without counting the outerTunnelTransport. This is also the size of the **IVpnPacketBuffers** in the Send pool. This value should be configured as mtuSize + [size of encapsulation headers], and should be <=1500. If it would be greater than 1500, mtuSize should be adjusted accordingly.
 
 ### -param Reserved
 Reserved

--- a/windows.networking.vpn/vpnchannel_startwithtrafficfilter_456344115.md
+++ b/windows.networking.vpn/vpnchannel_startwithtrafficfilter_456344115.md
@@ -32,7 +32,7 @@ A **Windows.Networking.DomainNameAssignment** object that represents the list of
 A UINT16 value specifying the MTU size of the VPN L3 network interface. This is also the size of the **IVpnPacketBuffers** in the Receive pool. This value should be configured to be at most 1400.
 
 ### -param maxFrameSize
-A UINT16 value specifying the max size of the frame defined by the VPN protocol encapsulation without counting the outerTunnelTransport. This is also the size of the **IVpnPacketBuffers** in the Send pool. This value should be configured as mtuSize + [size of encapsulation headers], and should be <=1500. If it would be greater than 1500, mtuSize should be adjusted accordingly.
+A UINT16 value specifying the max size of the frame defined by the VPN protocol encapsulation without counting the outerTunnelTransport. This is also the size of the **IVpnPacketBuffers** in the Send pool. This value should be configured as mtuSize + [size of encapsulation headers], and should be <=1500. If it would be greater than 1500 either mtuSize or encapsulation header size should be reduced as the platform limits the framesize to 1500.
 
 ### -param reserved
 Reserved.

--- a/windows.networking.vpn/vpnchannel_startwithtrafficfilter_456344115.md
+++ b/windows.networking.vpn/vpnchannel_startwithtrafficfilter_456344115.md
@@ -29,10 +29,10 @@ A **Windows.Networking.VpnRouteAssignment** object that represents the routes th
 A **Windows.Networking.DomainNameAssignment** object that represents the list of name prefixes that are associated with the VPN channel, including its DNS and proxy servers.
 
 ### -param mtuSize
-A UINT16 value specifying the MTU size of the VPN L3 network interface. This is also the size of the **IVpnPacketBuffers** in the Receive pool.
+A UINT16 value specifying the MTU size of the VPN L3 network interface. This is also the size of the **IVpnPacketBuffers** in the Receive pool. This value should be configured to be at most 1400.
 
 ### -param maxFrameSize
-A UINT16 value specifying the max size of the frame defined by the VPN protocol encapsulation without counting the outerTunnelTransport. This is also the size of the **IVpnPacketBuffers** in the Send pool.
+A UINT16 value specifying the max size of the frame defined by the VPN protocol encapsulation without counting the outerTunnelTransport. This is also the size of the **IVpnPacketBuffers** in the Send pool. This value should be configured as mtuSize + [size of encapsulation headers], and should be <=1500. If it would be greater than 1500, mtuSize should be adjusted accordingly.
 
 ### -param reserved
 Reserved.

--- a/windows.networking.vpn/vpnchannel_startwithtrafficfilter_794156625.md
+++ b/windows.networking.vpn/vpnchannel_startwithtrafficfilter_794156625.md
@@ -32,7 +32,7 @@ A **Windows.Networking.DomainNameAssignment** object that represents the list of
 A UINT16 value specifying the MTU size of the VPN L3 network interface. This is also the size of the **IVpnPacketBuffers** in the Receive pool. This value should be configured to be at most 1400.
 
 ### -param maxFrameSize
-A UINT16 value specifying the max size of the frame defined by the VPN protocol encapsulation without counting the outerTunnelTransport. This is also the size of the **IVpnPacketBuffers** in the Send pool. This value should be configured as mtuSize + [size of encapsulation headers], and should be <=1500. If it would be greater than 1500, mtuSize should be adjusted accordingly.
+A UINT16 value specifying the max size of the frame defined by the VPN protocol encapsulation without counting the outerTunnelTransport. This is also the size of the **IVpnPacketBuffers** in the Send pool. This value should be configured as mtuSize + [size of encapsulation headers], and should be <=1500. If it would be greater than 1500 either mtuSize or encapsulation header size should be reduced as the platform limits the framesize to 1500.
 
 ### -param reserved
 Reserved.

--- a/windows.networking.vpn/vpnchannel_startwithtrafficfilter_794156625.md
+++ b/windows.networking.vpn/vpnchannel_startwithtrafficfilter_794156625.md
@@ -29,10 +29,10 @@ A **Windows.Networking.VpnRouteAssignment** object that represents the routes th
 A **Windows.Networking.DomainNameAssignment** object that represents the list of name prefixes that are associated with the VPN channel, including its DNS and proxy servers.
 
 ### -param mtuSize
-A UINT16 value specifying the MTU size of the VPN L3 network interface. This is also the size of the **IVpnPacketBuffers** in the Receive pool.
+A UINT16 value specifying the MTU size of the VPN L3 network interface. This is also the size of the **IVpnPacketBuffers** in the Receive pool. This value should be configured to be at most 1400.
 
 ### -param maxFrameSize
-A UINT16 value specifying the max size of the frame defined by the VPN protocol encapsulation without counting the outerTunnelTransport. This is also the size of the **IVpnPacketBuffers** in the Send pool.
+A UINT16 value specifying the max size of the frame defined by the VPN protocol encapsulation without counting the outerTunnelTransport. This is also the size of the **IVpnPacketBuffers** in the Send pool. This value should be configured as mtuSize + [size of encapsulation headers], and should be <=1500. If it would be greater than 1500, mtuSize should be adjusted accordingly.
 
 ### -param reserved
 Reserved.


### PR DESCRIPTION
Internal investigation was done to dive further into how MTU/maxFrameSize are actually used with the UWP vpn platform. These updates are guidance based on the results of said investigation.