### PR TITLE
Add note to CredentialPicker API about non-UWP app restriction

### DIFF
--- a/windows.security.credentials.ui/credentialpicker_pickasync_1330776073.md
+++ b/windows.security.credentials.ui/credentialpicker_pickasync_1330776073.md
@@ -13,6 +13,7 @@ public Windows.Foundation.IAsyncOperation<Windows.Security.Credentials.UI.Creden
 Constructor used to initiate asynchronous prompting operations using three inputs.
 
 ## -parameters
+
 ### -param targetName
 The target name to display.
 
@@ -22,7 +23,8 @@ The message to display in the dialog box.
 ### -param caption
 The caption to display in the dialog box.
 
-Note: this value must be set for a non-UWP app.
+> [!NOTE]
+> This value must be set for a non-UWP (that is, desktop) app.
 
 ## -returns
 The credential and options from the user.

--- a/windows.security.credentials.ui/credentialpicker_pickasync_1330776073.md
+++ b/windows.security.credentials.ui/credentialpicker_pickasync_1330776073.md
@@ -22,6 +22,8 @@ The message to display in the dialog box.
 ### -param caption
 The caption to display in the dialog box.
 
+Note: this value must be set for a non-UWP app.
+
 ## -returns
 The credential and options from the user.
 

--- a/windows.security.credentials.ui/credentialpicker_pickasync_1621420115.md
+++ b/windows.security.credentials.ui/credentialpicker_pickasync_1621420115.md
@@ -16,6 +16,10 @@ Displays a dialog box to the user and collects credentials from the user.
 ### -param options
 The options on displaying and collecting the credential box.
 
+Note that in a non-UWP app, the
+[CredentialPickerOptions.Caption](https://docs.microsoft.com/uwp/api/Windows.Security.Credentials.UI.CredentialPickerOptions.Caption)
+must be set.
+
 ## -returns
 The credential and options from the user.
 

--- a/windows.security.credentials.ui/credentialpicker_pickasync_1621420115.md
+++ b/windows.security.credentials.ui/credentialpicker_pickasync_1621420115.md
@@ -16,9 +16,8 @@ Displays a dialog box to the user and collects credentials from the user.
 ### -param options
 The options on displaying and collecting the credential box.
 
-Note that in a non-UWP app, the
-[CredentialPickerOptions.Caption](https://docs.microsoft.com/uwp/api/Windows.Security.Credentials.UI.CredentialPickerOptions.Caption)
-must be set.
+> [!NOTE]
+> In a non-UWP (that is, desktop) app, the [CredentialPickerOptions.Caption](/uwp/api/Windows.Security.Credentials.UI.CredentialPickerOptions.Caption) must be set.
 
 ## -returns
 The credential and options from the user.

--- a/windows.security.credentials.ui/credentialpicker_pickasync_693496969.md
+++ b/windows.security.credentials.ui/credentialpicker_pickasync_693496969.md
@@ -24,8 +24,7 @@ The credential and options from the user.
 
 ## -remarks
 
-This method is only supported in a UWP app.
-In a non-UWP app use the 3 parameter overload and set the `caption` parameter.
+This method is supported only in UWP apps. In a non-UWP (that is, desktop) app, use the three-parameter overload, and set the *caption* parameter.
 
 ## -examples
 

--- a/windows.security.credentials.ui/credentialpicker_pickasync_693496969.md
+++ b/windows.security.credentials.ui/credentialpicker_pickasync_693496969.md
@@ -24,6 +24,9 @@ The credential and options from the user.
 
 ## -remarks
 
+This method is only supported in a UWP app.
+In a non-UWP app use the 3 parameter overload and set the `caption` parameter.
+
 ## -examples
 
 ## -see-also


### PR DESCRIPTION
Adds notes to API pages about a restriction in the [CredentialPicker](https://docs.microsoft.com/uwp/api/Windows.Security.Credentials.UI.CredentialPicker) class that outside of UWP you must provide a Caption. In UWP apps it's optional because it can be queried from the app container.

Note that this page should also be updated once this PR is completed, but it's in another repo:
https://github.com/MicrosoftDocs/windows-dev-docs/blob/docs/hub/apps/desktop/modernize/desktop-to-uwp-supported-api.md

