### PR TITLE
[DRAFT][Accessibility] Document WinAppSDK alternative for HighContrastChanged

### DIFF
--- a/windows.ui.viewmanagement/accessibilitysettings_highcontrastchanged.md
+++ b/windows.ui.viewmanagement/accessibilitysettings_highcontrastchanged.md
@@ -14,6 +14,12 @@ Occurs when the system high contrast feature turns on or off.
 
 ## -remarks
 
+> [!WARNING]
+> This method will not work in WinUI 3 apps.
+>
+> Instead, use the [ThemeSettings.Changed](/windows/windows-app-sdk/api/winrt/microsoft.ui.system.themesettings.changed)
+> event. See [Mapping UWP APIs and libraries to the Windows App SDK](/windows/apps/windows-app-sdk/migrate-to-windows-app-sdk/api-mapping-table).
+
 ## -examples
 
 ## -see-also


### PR DESCRIPTION
WinAppSDK devs devs will find that the `HighContrastChanged` event does not work (it may crashes!) in WinUI 3 apps. This change documents the replacement API.

See [similar change in WinAppSDK docs](https://github.com/MicrosoftDocs/windows-dev-docs/pull/5300) & [issue in WinAppSDK codebase](https://github.com/microsoft/microsoft-ui-xaml/issues/4163)

> [!WARNING]
> HOLD until we validate this is a complete replacement.