### PR TITLE
Add cross-links between Calendar.ChangeCalendarSystem and CalendarIdentifiers pages 

### DIFF
--- a/windows.globalization/calendar_changecalendarsystem_1371050862.md
+++ b/windows.globalization/calendar_changecalendarsystem_1371050862.md
@@ -14,7 +14,7 @@ Sets a new calendar system to be used by this [Calendar](calendar.md) object.
 
 ## -parameters
 ### -param value
-The calendar identifier to use.
+The calendar identifier to use. This can be any identifier from the [CalendarIdentifiers](calendaridentifiers.md) class.
 
 ## -remarks
 

--- a/windows.globalization/calendaridentifiers.md
+++ b/windows.globalization/calendaridentifiers.md
@@ -26,16 +26,20 @@ Contains the calendar identifiers for the supported calendars, as static propert
 | 1607 | 14393 | VietnameseLunar |
 
 ## -examples
-Using the [Windows.Globalization.Calendar](calendar.md) API,
+
+The following example shows how to specify a [Calendar](calendar.md) system using the [ChangeCalendarSystem](changecalendarsystem.md) method.
+
 ```
 winrt::Windows::Globalization::Calendar calendar;
 calendar.ChangeCalendarSystem(winrt::Windows::Globalization::CalendarIdentifiers::Gregorian);
+// Perform Gregorian calendar calculations.
 ...
-// Perform some Gregorian-dependent calculations
-...
+
 calendar.ChangeCalendarSystem(winrt::Windows::Globalization::CalendarIdentifiers::Hebrew);
-// Perform Hebrew calendar calculations
+// Perform Hebrew calendar calculations.
+...
 ```
+
 ## -see-also
 
-[Date and time formatting sample (Windows 10)](https://github.com/Microsoft/Windows-universal-samples/tree/master/Samples/DateTimeFormatting), [Calendar sample (Windows 10)](https://go.microsoft.com/fwlink/p/?LinkId=624043), 
+[Date and time formatting sample (Windows 10)](https://github.com/Microsoft/Windows-universal-samples/tree/master/Samples/DateTimeFormatting), [Calendar sample (Windows 10)](https://go.microsoft.com/fwlink/p/?LinkId=624043)

--- a/windows.globalization/calendaridentifiers.md
+++ b/windows.globalization/calendaridentifiers.md
@@ -26,7 +26,16 @@ Contains the calendar identifiers for the supported calendars, as static propert
 | 1607 | 14393 | VietnameseLunar |
 
 ## -examples
-
+Using the [Windows.Globalization.Calendar](calendar.md) API,
+```
+winrt::Windows::Globalization::Calendar calendar;
+calendar.ChangeCalendarSystem(winrt::Windows::Globalization::CalendarIdentifiers::Gregorian);
+...
+// Perform some Gregorian-dependent calculations
+...
+calendar.ChangeCalendarSystem(winrt::Windows::Globalization::CalendarIdentifiers::Hebrew);
+// Perform Hebrew calendar calculations
+```
 ## -see-also
 
-[Date and time formatting sample (Windows 10)](https://github.com/Microsoft/Windows-universal-samples/tree/master/Samples/DateTimeFormatting), [Calendar sample (Windows 10)](https://go.microsoft.com/fwlink/p/?LinkId=624043)
+[Date and time formatting sample (Windows 10)](https://github.com/Microsoft/Windows-universal-samples/tree/master/Samples/DateTimeFormatting), [Calendar sample (Windows 10)](https://go.microsoft.com/fwlink/p/?LinkId=624043), 


### PR DESCRIPTION
Currently, it's not super clear what inputs the `ChangeCalendarSystem` method takes. This change adds cross linking to clarify. 