### PR TITLE
[DateTimeFormatter] Document basis for params for DateTimeFormatter

### DIFF
--- a/windows.globalization.datetimeformatting/datetimeformatter_datetimeformatter_1042679024.md
+++ b/windows.globalization.datetimeformatting/datetimeformatter_datetimeformatter_1042679024.md
@@ -25,21 +25,21 @@ The list of language identifiers, in priority order, that represent the choice o
 
 ### -param geographicRegion
 
-The identifier for the geographic region. This identifier is used for resolving the template to a pattern.
+The identifier for the geographic region. This identifier is used for resolving the template to a pattern. It should be a valid constructor for a [GeographicRegion](windows.globalization.geographicregion.md); in other words, one of the ISO 3166-1 two-letter or three-letter codes that identify the country, or one of the three-digit UN-M49 codes that identify the geographical region.
 
 ### -param calendar
 
-The calendar identifier to use.
+The calendar identifier to use. This should be one of the well-known [CalendarIdentifiers](windows.globalization.calendaridentifiers.md).
 
 ### -param clock
 
-The clock identifier to use.
+The clock identifier to use. This should be one of the well-known [ClockIdentifiers](windows.globalization.clockidentifiers.md).
 
 ## -remarks
 
 If your app passes language tags used in this class to any [National Language Support](/windows/desktop/Intl/national-language-support) functions, it must first convert the tags by calling [ResolveLocaleName](/windows/desktop/api/winnls/nf-winnls-resolvelocalename).
 
-Language tags support the Unicode extensions "ca-" and "nu-". (See [Unicode Key/Type Definitions](https://www.unicode.org/reports/tr35/#Key_Type_Definitions).) Note that these extensions can affect the calendar used by Calendar objects.
+Language tags support the Unicode extensions "ca-" and "nu-". (See [Unicode Key/Type Definitions](https://www.unicode.org/reports/tr35/#Key_Type_Definitions).) Note that these extensions can affect the calendar used by Clock objects.
 
 ## -examples
 

--- a/windows.globalization.datetimeformatting/datetimeformatter_datetimeformatter_1042679024.md
+++ b/windows.globalization.datetimeformatting/datetimeformatter_datetimeformatter_1042679024.md
@@ -29,11 +29,11 @@ The identifier for a [GeographicRegion](windows.globalization.geographicregion.m
 
 ### -param calendar
 
-The calendar identifier to use. This should be one of the well-known [CalendarIdentifiers](windows.globalization.calendaridentifiers.md).
+The calendar identifier to use. This should be a value from [CalendarIdentifiers](windows.globalization.calendaridentifiers.md).
 
 ### -param clock
 
-The clock identifier to use. This should be one of the well-known [ClockIdentifiers](windows.globalization.clockidentifiers.md).
+The clock identifier to use. This should be a value from [ClockIdentifiers](windows.globalization.clockidentifiers.md).
 
 ## -remarks
 

--- a/windows.globalization.datetimeformatting/datetimeformatter_datetimeformatter_1042679024.md
+++ b/windows.globalization.datetimeformatting/datetimeformatter_datetimeformatter_1042679024.md
@@ -39,7 +39,7 @@ The clock identifier to use. This should be a value from [ClockIdentifiers](wind
 
 If your app passes language tags used in this class to any [National Language Support](/windows/desktop/Intl/national-language-support) functions, it must first convert the tags by calling [ResolveLocaleName](/windows/desktop/api/winnls/nf-winnls-resolvelocalename).
 
-Language tags support the Unicode extensions "ca-" and "nu-". (See [Unicode Key/Type Definitions](https://www.unicode.org/reports/tr35/#Key_Type_Definitions).) Note that these extensions can affect the calendar used by Clock objects.
+Language tags support the Unicode extensions "ca-" and "nu-". (See [Unicode Key/Type Definitions](https://www.unicode.org/reports/tr35/#Key_Type_Definitions).) Note that these extensions can affect the calendar used by Calendar objects.
 
 ## -examples
 

--- a/windows.globalization.datetimeformatting/datetimeformatter_datetimeformatter_1042679024.md
+++ b/windows.globalization.datetimeformatting/datetimeformatter_datetimeformatter_1042679024.md
@@ -25,7 +25,7 @@ The list of language identifiers, in priority order, that represent the choice o
 
 ### -param geographicRegion
 
-The identifier for the geographic region. This identifier is used for resolving the template to a pattern. It should be a valid constructor for a [GeographicRegion](windows.globalization.geographicregion.md); in other words, one of the ISO 3166-1 two-letter or three-letter codes that identify the country, or one of the three-digit UN-M49 codes that identify the geographical region.
+The identifier for a [GeographicRegion](windows.globalization.geographicregion.md) used to resolve the template to a pattern. This should be an ISO 3166-1 two-letter or three-letter code that identifies the country, or one of the three-digit UN-M49 codes that identify the geographical region.
 
 ### -param calendar
 


### PR DESCRIPTION
A lot of the params for [`Windows.Globalization.DateTimeFormatter`](https://learn.microsoft.com/en-us/uwp/api/windows.globalization.datetimeformatting.datetimeformatter?view=winrt-26100) need specific strings. This documents the formats.

Verified here: https://github.com/citelao/CalendarTesting/blob/master/Program.cs

## See also

* https://learn.microsoft.com/en-us/uwp/api/windows.globalization.geographicregion.-ctor?view=winrt-26100#windows-globalization-geographicregion-ctor(system-string)