### PR TITLE
App extension public folder is in the package location and immutable to hosts and extensions

### DIFF
--- a/windows.applicationmodel.appextensions/appextension_getpublicfolder_126839260.md
+++ b/windows.applicationmodel.appextensions/appextension_getpublicfolder_126839260.md
@@ -11,7 +11,7 @@ public Windows.Storage.StorageFolder GetPublicFolder ();
 
 ## -description
 
-Gets the subfolder provided by the `PublicFolder` in the app extension for sharing files between the extension and the host.
+Gets the subfolder provided by the `PublicFolder` attribute in the app extension for sharing files between the extension and the host.
 
 ## -returns
 

--- a/windows.applicationmodel.appextensions/appextension_getpublicfolder_126839260.md
+++ b/windows.applicationmodel.appextensions/appextension_getpublicfolder_126839260.md
@@ -11,7 +11,7 @@ public Windows.Storage.StorageFolder GetPublicFolder ();
 
 ## -description
 
-Gets the readable subfolder in the extension's isolated storage.
+Gets the subfolder provided by the `PublicFolder` in the app extension for sharing files between the extension and the host.
 
 ## -returns
 
@@ -19,7 +19,8 @@ The public sub-folder.
 
 ## -remarks
 
-An extension can provide a subfolder containing files that hosting apps can read from. Hosts cannot write to the folder.
+Extensions must create this folder by populating it with files as part of their package defintion. It is read-only to both the
+extension and its host.
 
 ## -examples
 

--- a/windows.applicationmodel.appextensions/appextension_getpublicfolder_126839260.md
+++ b/windows.applicationmodel.appextensions/appextension_getpublicfolder_126839260.md
@@ -19,8 +19,7 @@ The public sub-folder.
 
 ## -remarks
 
-Extensions must create this folder by populating it with files as part of their package defintion. It is read-only to both the
-extension and its host.
+Extensions must create this folder by populating it with files as part of their package definition. It is read-only to both the extension and its host.
 
 ## -examples
 

--- a/windows.applicationmodel.appextensions/appextension_getpublicfolderasync_353057648.md
+++ b/windows.applicationmodel.appextensions/appextension_getpublicfolderasync_353057648.md
@@ -11,7 +11,7 @@ public Windows.Foundation.IAsyncOperation<Windows.Storage.StorageFolder> GetPubl
 
 ## -description
 
-Gets the readable subfolder in the extension's isolated storage.
+Gets the subfolder provided by the `PublicFolder` attribute in the app extension for sharing files between the extension and the host.
 
 ## -returns
 
@@ -19,7 +19,8 @@ The public sub-folder.
 
 ## -remarks
 
-An extension can provide a subfolder containing files that hosting apps can read from. Hosts cannot write to the folder.
+Extensions must create this folder by populating it with files as part of their package defintion. It is read-only to both the
+extension and its host.
 
 ## -examples
 

--- a/windows.applicationmodel.appextensions/appextension_getpublicfolderasync_353057648.md
+++ b/windows.applicationmodel.appextensions/appextension_getpublicfolderasync_353057648.md
@@ -19,8 +19,7 @@ The public sub-folder.
 
 ## -remarks
 
-Extensions must create this folder by populating it with files as part of their package defintion. It is read-only to both the
-extension and its host.
+Extensions must create this folder by populating it with files as part of their package definition. It is read-only to both the extension and its host.
 
 ## -examples
 


### PR DESCRIPTION
The current docs are unclear; the public folder is immutable to both the host and the extension and must be created based on the package contents of the extension. 