### PR TITLE
Docs(Geolocator.ReportInterval): Clarify zero unsupported; 1 is minimum valid value

### DIFF
--- a/windows.devices.geolocation/geolocator_reportinterval.md
+++ b/windows.devices.geolocation/geolocator_reportinterval.md
@@ -16,6 +16,9 @@ The requested minimum time interval between location updates, in milliseconds. I
 The requested minimum time interval between location updates.
 
 ## -remarks
+> [!IMPORTANT]
+> `ReportInterval` must be greater than or equal to 1. Passing `0` is not supported and is treated as “not set”. To request the minimum supported update interval, set `ReportInterval` to `1`.
+
 The default report interval is 1 second or as frequent as the hardware can support – whichever is shorter. Location updates can be set to a different frequency if you specify a [MovementThreshold](geolocator_movementthreshold.md) or set ReportInterval to a different value. If your app sets both [MovementThreshold](geolocator_movementthreshold.md) and ReportInterval, location will be updated according to [MovementThreshold](geolocator_movementthreshold.md).
 
 If another application has requested more frequent updates, by specifying a smaller value for ReportInterval, your application may receive updates at a higher frequency than requested.

--- a/windows.devices.geolocation/geolocator_reportinterval.md
+++ b/windows.devices.geolocation/geolocator_reportinterval.md
@@ -17,7 +17,7 @@ The requested minimum time interval between location updates.
 
 ## -remarks
 > [!IMPORTANT]
-> `ReportInterval` must be greater than or equal to 1. Passing `0` is not supported and is treated as “not set”. To request the minimum supported update interval, set `ReportInterval` to `1` (1 millisecond).
+> The value of **ReportInterval** must be greater than or equal to 1. Passing 0 is not supported, and is treated as *not set*. To request the minimum supported update interval, set **ReportInterval** to 1 (1 millisecond).
 
 The default report interval is 1 second or as frequent as the hardware can support – whichever is shorter. Location updates can be set to a different frequency if you specify a [MovementThreshold](geolocator_movementthreshold.md) or set ReportInterval to a different value. If your app sets both [MovementThreshold](geolocator_movementthreshold.md) and ReportInterval, location will be updated according to [MovementThreshold](geolocator_movementthreshold.md).
 

--- a/windows.devices.geolocation/geolocator_reportinterval.md
+++ b/windows.devices.geolocation/geolocator_reportinterval.md
@@ -17,7 +17,7 @@ The requested minimum time interval between location updates.
 
 ## -remarks
 > [!IMPORTANT]
-> `ReportInterval` must be greater than or equal to 1. Passing `0` is not supported and is treated as “not set”. To request the minimum supported update interval, set `ReportInterval` to `1`.
+> `ReportInterval` must be greater than or equal to 1. Passing `0` is not supported and is treated as “not set”. To request the minimum supported update interval, set `ReportInterval` to `1` (1 millisecond).
 
 The default report interval is 1 second or as frequent as the hardware can support – whichever is shorter. Location updates can be set to a different frequency if you specify a [MovementThreshold](geolocator_movementthreshold.md) or set ReportInterval to a different value. If your app sets both [MovementThreshold](geolocator_movementthreshold.md) and ReportInterval, location will be updated according to [MovementThreshold](geolocator_movementthreshold.md).
 


### PR DESCRIPTION
Adds an Important note to Geolocator.ReportInterval remarks:

- ReportInterval must be ≥ 1.
- Passing 0 is not supported and is treated as “not set”.
- To request the minimum supported interval, set ReportInterval = 1.

Doc-only clarification aligned with product behavior; no code changes.

I work on the Windows Geolocation area; this reflects actual runtime behavior and avoids confusion when apps set 0.
