### PR TITLE
Update pathio_writebytesasync_1599878576.md to say it writes the enti…

### DIFF
--- a/windows.storage/pathio_writebytesasync_1599878576.md
+++ b/windows.storage/pathio_writebytesasync_1599878576.md
@@ -10,7 +10,8 @@ public Windows.Foundation.IAsyncAction WriteBytesAsync(System.String absolutePat
 # Windows.Storage.PathIO.WriteBytesAsync
 
 ## -description
-Writes an entire array of bytes of data to the file at the specified path or Uniform Resource Identifier (URI).
+
+Writes an array of bytes of data to the file at the specified path or Uniform Resource Identifier (URI).
 
 ## -parameters
 ### -param absolutePath

--- a/windows.storage/pathio_writebytesasync_1599878576.md
+++ b/windows.storage/pathio_writebytesasync_1599878576.md
@@ -10,7 +10,7 @@ public Windows.Foundation.IAsyncAction WriteBytesAsync(System.String absolutePat
 # Windows.Storage.PathIO.WriteBytesAsync
 
 ## -description
-Writes a single byte of data to the file at the specified path or Uniform Resource Identifier (URI).
+Writes an entire array of bytes of data to the file at the specified path or Uniform Resource Identifier (URI).
 
 ## -parameters
 ### -param absolutePath


### PR DESCRIPTION
…re buffer, not just a single byte

The documentation description is clearly wrong -- obviously a method "WriteBytes" that takes an array will write all of the bytes, not just one.