### PR TITLE
Windows.System.User: add Remarks to FindAllAsync overloads and GetFromId

### DIFF
--- a/windows.system/user_findallasync_1333355945.md
+++ b/windows.system/user_findallasync_1333355945.md
@@ -23,6 +23,10 @@ The authentication status of users to find.
 When this method completes successfully, it returns a list (type [IVectorView](../windows.foundation.collections/ivectorview_1.md)) of [Users](user.md).
 
 ## -remarks
+> [!WARNING]
+> This overload is deprecated. Use [FindAllAsync](user_findallasync_326280522.md) or [GetDefault](user_getdefault_846721868.md) instead.
+
+On desktop platforms, this method returns at most one user—the interactive user associated with the caller's current session. On Xbox, the list may contain multiple users when more than one user is signed in simultaneously. The method does not enumerate all accounts stored on the device.
 
 ## -examples
 

--- a/windows.system/user_findallasync_1333355945.md
+++ b/windows.system/user_findallasync_1333355945.md
@@ -26,10 +26,11 @@ When this method completes successfully, it returns a list (type [IVectorView](.
 > [!WARNING]
 > This overload is deprecated. Use [FindAllAsync](user_findallasync_326280522.md) or [GetDefault](user_getdefault_846721868.md) instead.
 
-On desktop platforms, this method returns at most one user—the interactive user associated with the caller's current session. On Xbox, the list may contain multiple users when more than one user is signed in simultaneously. The method does not enumerate all accounts stored on the device.
+This method returns users who are currently signed in to the same session as the calling application. It does not enumerate all accounts stored on the device.
+
+To get the user running the current process directly, use [GetDefault](user_getdefault_846721868.md) (available from Windows 10, version 2104).
 
 ## -examples
 
 ## -see-also
-| [FindAllAsync](user_findallasync_326280522.md)
-| [FindAllAsync(UserType)](user_findallasync_711678667.md)
+[FindAllAsync](user_findallasync_326280522.md), [FindAllAsync(UserType)](user_findallasync_711678667.md)

--- a/windows.system/user_findallasync_1333355945.md
+++ b/windows.system/user_findallasync_1333355945.md
@@ -31,4 +31,5 @@ On desktop platforms, this method returns at most one user—the interactive use
 ## -examples
 
 ## -see-also
-[FindAllAsync](user_findallasync_326280522.md), [FindAllAsync(UserType)](user_findallasync_711678667.md)
+| [FindAllAsync](user_findallasync_326280522.md)
+| [FindAllAsync(UserType)](user_findallasync_711678667.md)

--- a/windows.system/user_findallasync_326280522.md
+++ b/windows.system/user_findallasync_326280522.md
@@ -16,6 +16,9 @@ Finds all users asynchronously.
 When this method completes successfully, it returns a list (type [IVectorView](../windows.foundation.collections/ivectorview_1.md)) of [Users](user.md).
 
 ## -remarks
+On desktop platforms, this method returns at most one user—the interactive user associated with the caller's current session. On Xbox, the list may contain multiple users when more than one user is signed in simultaneously. The method does not enumerate all accounts stored on the device.
+
+To get the user running the current process directly, use [GetDefault](user_getdefault_846721868.md) (available from Windows 10, version 2104).
 
 ## -examples
 

--- a/windows.system/user_findallasync_326280522.md
+++ b/windows.system/user_findallasync_326280522.md
@@ -16,11 +16,11 @@ Finds all users asynchronously.
 When this method completes successfully, it returns a list (type [IVectorView](../windows.foundation.collections/ivectorview_1.md)) of [Users](user.md).
 
 ## -remarks
-On desktop platforms, this method returns at most one user—the interactive user associated with the caller's current session. On Xbox, the list may contain multiple users when more than one user is signed in simultaneously. The method does not enumerate all accounts stored on the device.
+This method returns users who are currently signed in to the same session as the calling application. It does not enumerate all accounts stored on the device.
 
 To get the user running the current process directly, use [GetDefault](user_getdefault_846721868.md) (available from Windows 10, version 2104).
 
 ## -examples
 
 ## -see-also
-| [FindAllAsync(UserType)](user_findallasync_711678667.md), [FindAllAsync(UserType, UserAuthenticationStatus)](user_findallasync_1333355945.md)
+[FindAllAsync(UserType)](user_findallasync_711678667.md), [FindAllAsync(UserType, UserAuthenticationStatus)](user_findallasync_1333355945.md)

--- a/windows.system/user_findallasync_326280522.md
+++ b/windows.system/user_findallasync_326280522.md
@@ -23,4 +23,4 @@ To get the user running the current process directly, use [GetDefault](user_getd
 ## -examples
 
 ## -see-also
-[FindAllAsync(UserType)](user_findallasync_711678667.md), [FindAllAsync(UserType, UserAuthenticationStatus)](user_findallasync_1333355945.md)
+| [FindAllAsync(UserType)](user_findallasync_711678667.md), [FindAllAsync(UserType, UserAuthenticationStatus)](user_findallasync_1333355945.md)

--- a/windows.system/user_findallasync_711678667.md
+++ b/windows.system/user_findallasync_711678667.md
@@ -27,4 +27,4 @@ To get the user running the current process directly, use [GetDefault](user_getd
 ## -examples
 
 ## -see-also
-[FindAllAsync](user_findallasync_326280522.md), [FindAllAsync(UserType, UserAuthenticationStatus)](user_findallasync_1333355945.md)
+| [FindAllAsync](user_findallasync_326280522.md), [FindAllAsync(UserType, UserAuthenticationStatus)](user_findallasync_1333355945.md)

--- a/windows.system/user_findallasync_711678667.md
+++ b/windows.system/user_findallasync_711678667.md
@@ -20,6 +20,9 @@ The type of users to find.
 When this method completes successfully, it returns a list (type [IVectorView](../windows.foundation.collections/ivectorview_1.md)) of [Users](user.md).
 
 ## -remarks
+On desktop platforms, this method returns at most one user—the interactive user associated with the caller's current session. On Xbox, the list may contain multiple users when more than one user is signed in simultaneously. The method does not enumerate all accounts stored on the device.
+
+To get the user running the current process directly, use [GetDefault](user_getdefault_846721868.md) (available from Windows 10, version 2104).
 
 ## -examples
 

--- a/windows.system/user_findallasync_711678667.md
+++ b/windows.system/user_findallasync_711678667.md
@@ -20,11 +20,11 @@ The type of users to find.
 When this method completes successfully, it returns a list (type [IVectorView](../windows.foundation.collections/ivectorview_1.md)) of [Users](user.md).
 
 ## -remarks
-On desktop platforms, this method returns at most one user—the interactive user associated with the caller's current session. On Xbox, the list may contain multiple users when more than one user is signed in simultaneously. The method does not enumerate all accounts stored on the device.
+This method returns users who are currently signed in to the same session as the calling application. It does not enumerate all accounts stored on the device.
 
 To get the user running the current process directly, use [GetDefault](user_getdefault_846721868.md) (available from Windows 10, version 2104).
 
 ## -examples
 
 ## -see-also
-| [FindAllAsync](user_findallasync_326280522.md), [FindAllAsync(UserType, UserAuthenticationStatus)](user_findallasync_1333355945.md)
+[FindAllAsync](user_findallasync_326280522.md), [FindAllAsync(UserType, UserAuthenticationStatus)](user_findallasync_1333355945.md)

--- a/windows.system/user_getfromid_2093276151.md
+++ b/windows.system/user_getfromid_2093276151.md
@@ -20,6 +20,9 @@ The Id of the user to get.
 The user with the given Id.
 
 ## -remarks
+If no user with the given *nonRoamableId* is found, this method returns **null**. Always check the return value before using it.
+
+A *nonRoamableId* can be obtained from the [NonRoamableId](user_nonroamableid.md) property of a [User](user.md) object. This identifier is device-specific and is not roamed to other devices.
 
 ## -examples
 


### PR DESCRIPTION
Addresses ADO work item #311108 (GitHub issues #1144, #1742, #1195).

## Changes

### FindAllAsync (all three overloads)
- Added `## -remarks` explaining that on **desktop**, the method returns at most one user (the interactive user in the caller's session); on **Xbox**, it may return multiple users. The method does not enumerate all accounts on the device.
- Added cross-reference to `GetDefault` (Windows 10, version 2104) as the preferred API for identifying the current process user.
- The deprecated `FindAllAsync(UserType, UserAuthenticationStatus)` overload now includes a `[!WARNING]` callout directing users to `FindAllAsync` or `GetDefault`.

### GetFromId
- Added `## -remarks` documenting that passing an unrecognized `nonRoamableId` returns **null**, and noting the device-specific nature of the identifier.

## Not in this PR
Issue #1830 (`GetPropertiesAsync` — AAD AccountName/DomainName table accuracy) is tracked separately. The customer reports the AAD column may be wrong (AccountName available, DomainName not). The issue was 6 years old and lacked information and so was closed.