### PR TITLE
PackageManager.FindPackages: clarify user scope and parameter formats

### DIFF
--- a/windows.management.deployment/packagemanager_findpackages_1246181969.md
+++ b/windows.management.deployment/packagemanager_findpackages_1246181969.md
@@ -10,13 +10,15 @@ public Windows.Foundation.Collections.IIterable<Windows.ApplicationModel.Package
 # Windows.Management.Deployment.PackageManager.FindPackages
 
 ## -description
-Retrieves information about a specified family of [Packages](/uwp/api/windows.applicationmodel.package) installed across all users.
+Retrieves information about all [Packages](/uwp/api/windows.applicationmodel.package) installed across all users.
 
 ## -returns
 If the method succeeds, an enumerable collection of package objects is returned. Each Package object in this collection contains information about the package, including but not limited to its name, publisher, version, and install location.
 
 ## -remarks
 This method requires administrative privileges. Otherwise, an **AccessDeniedException** is thrown.
+
+This method returns packages installed for **all users** on the device. To retrieve packages for a specific user only, use [FindPackagesForUser](packagemanager_findpackagesforuser_292215772.md).
 
 ## -examples
 This example uses FindPackages() to enumerate the installed packages for all users.

--- a/windows.management.deployment/packagemanager_findpackages_1597689551.md
+++ b/windows.management.deployment/packagemanager_findpackages_1597689551.md
@@ -23,7 +23,15 @@ The package publisher. This parameter cannot be **null**.
 If the method succeeds, an enumerable collection of package objects with the same package name and publisher name is returned. Each Package object in this collection contains information about the package, including but not limited to its name, publisher, version, and install location. If no packages with the specified name and publisher are found, this method returns an empty list.
 
 ## -remarks
-This method requires administrative privileges.
+This method requires administrative privileges. This method returns packages installed for **all users** on the device, not just the current user. To retrieve packages for a specific user only, use [FindPackagesForUser](packagemanager_findpackagesforuser_292215772.md).
+
+> [!NOTE]
+> Parameter formats matter — passing the wrong format silently returns an empty collection:
+>
+> - The *packageName* parameter corresponds to [Package.Id.Name](/uwp/api/windows.applicationmodel.packageid.name) — for example, `Microsoft.WindowsCalculator`. This is **not** [Package.Id.FullName](/uwp/api/windows.applicationmodel.packageid.fullname) (which includes version and architecture).
+> - The *packagePublisher* parameter corresponds to [Package.Id.Publisher](/uwp/api/windows.applicationmodel.packageid.publisher) — the full X.500 distinguished name string, for example, `CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US`. This is **not** [Package.Id.PublisherId](/uwp/api/windows.applicationmodel.packageid.publisherid) (the hashed short form).
+>
+> Use [FindPackages(String)](packagemanager_findpackages_331793265.md) with [Package.Id.FamilyName](/uwp/api/windows.applicationmodel.packageid.familyname) as a simpler and less error-prone alternative when you don't need to match on publisher separately.
 
 ## -examples
 

--- a/windows.management.deployment/packagemanager_findpackages_331793265.md
+++ b/windows.management.deployment/packagemanager_findpackages_331793265.md
@@ -22,6 +22,9 @@ If the method succeeds, an enumerable collection of package objects with the sam
 ## -remarks
 This method requires administrative privileges. Each package in the [IIterable(Package)](../windows.foundation.collections/iiterable_1.md) collection may be installed for the current user or for another user. This method differs from [FindPackages(String packageName, String pulisherName)](packagemanager_findpackages_1597689551.md) method. Here the *packageFamilyName* parameter is a single string, comprised of the package name and package publisher hash.
 
+> [!NOTE]
+> The *packageFamilyName* parameter corresponds to [Package.Id.FamilyName](/uwp/api/windows.applicationmodel.packageid.familyname) — for example, `Microsoft.WindowsCalculator_8wekyb3d8bbwe`. This is **not** the same as [Package.Id.Name](/uwp/api/windows.applicationmodel.packageid.name) (e.g., `Microsoft.WindowsCalculator`) or [Package.Id.FullName](/uwp/api/windows.applicationmodel.packageid.fullname) (which includes version and architecture). Passing an incorrect format silently returns an empty collection.
+
 ## -examples
 
 ## -see-also


### PR DESCRIPTION
Fixes MicrosoftDocs/windows-dev-docs#5503

Community feedback: the `FindPackages` overloads don't explain whether they return packages for all users or just the current user, and the `packageName`/`packageFamilyName` parameter formats are ambiguous — passing the wrong format silently returns an empty collection.

## Changes

### `FindPackages()`
- Fixed incorrect description ('specified family' was copy-pasted from sibling overload) — this overload returns **all** packages
- Added note that results span all users; pointed to `FindPackagesForUser` for per-user queries

### `FindPackages(String familyName)`
- Added `[!NOTE]` clarifying `packageFamilyName` = `Package.Id.FamilyName` (e.g. `Microsoft.WindowsCalculator_8wekyb3d8bbwe`), **not** `Id.Name` or `Id.FullName`
- Called out that the wrong format silently returns an empty collection

### `FindPackages(String name, String publisher)`
- Remarks were nearly empty — filled in completely:
  - All-users scope now stated explicitly; pointer to `FindPackagesForUser` for per-user queries
  - `packageName` = `Package.Id.Name` (not `FullName`)
  - `packagePublisher` = `Package.Id.Publisher` (full X.500 DN, not `PublisherId`)
  - Recommends `FindPackages(FamilyName)` as a simpler, less error-prone alternative