### PR TITLE
Fix description grammar in ResourceDictionary documentation

### DIFF
--- a/windows.ui.xaml/resourcedictionary.md
+++ b/windows.ui.xaml/resourcedictionary.md
@@ -10,7 +10,7 @@ public class ResourceDictionary : Windows.UI.Xaml.DependencyObject, Windows.Foun
 # Windows.UI.Xaml.ResourceDictionary
 
 ## -description
-Defines a repository for XAML resources, such as styles, that your app uses. You define the resources in XAML and can then retrieve them in XAML using the [{StaticResource} markup extension](/windows/uwp/xaml-platform/staticresource-markup-extension) and [{ThemeResource} markup extension](/windows/uwp/xaml-platform/themeresource-markup-extension) s. You can also access resources with code, but that is less common.
+Defines a repository for XAML resources, such as styles, that your app uses. You define the resources in XAML and can then retrieve them in XAML using the [{StaticResource} markup extension](/windows/uwp/xaml-platform/staticresource-markup-extension) and [{ThemeResource} markup extension](/windows/uwp/xaml-platform/themeresource-markup-extension). You can also access resources with code, but that is less common.
 
 
 


### PR DESCRIPTION
The original had a space-s after the second "extension". Possibly the 's' should be there (IMHO, no), but it definitely should not have had a space before it!