### PR TITLE
Document RemoteDesktopRegistrar.ConnectionCenterRequested event (ADO #562869)

### DIFF
--- a/windows.system.remotedesktop.provider/remotedesktopregistrar.md
+++ b/windows.system.remotedesktop.provider/remotedesktopregistrar.md
@@ -19,8 +19,11 @@ Provides methods for querying the status of the remote desktop features enabled 
 
 ## -remarks
 
+## -events
 
-
+| Event | Description |
+|-------|-------------|
+| [ConnectionCenterRequested](remotedesktopregistrar_connectioncenterrequested.md) | Raised when the user requests the boot to cloud Connection Center. |
 
 ## -see-also
 

--- a/windows.system.remotedesktop.provider/remotedesktopregistrar_connectioncenterrequested.md
+++ b/windows.system.remotedesktop.provider/remotedesktopregistrar_connectioncenterrequested.md
@@ -1,0 +1,30 @@
+---
+-api-id: E:Windows.System.RemoteDesktop.Provider.RemoteDesktopRegistrar.ConnectionCenterRequested
+-api-type: winrt event
+---
+
+# Windows.System.RemoteDesktop.Provider.RemoteDesktopRegistrar.ConnectionCenterRequested
+
+<!--
+public static event Windows.Foundation.EventHandler<object> ConnectionCenterRequested;
+-->
+
+
+## -description
+
+Raised when the user requests the boot to cloud Connection Center in a remote desktop provider app.
+
+## -remarks
+
+Remote desktop provider apps running in the [boot to cloud](/windows-365/enterprise/windows-365-boot-overview#connection-center-at-logon) scenario should subscribe to this event to receive notifications when the user has requested the Connection Center. When the event is raised, the app should display the Connection Center UI to the user.
+
+> [!IMPORTANT]
+> The **RemoteDesktopRegistrar** API is part of a Limited Access Feature (see [LimitedAccessFeatures class](/uwp/api/windows.applicationmodel.limitedaccessfeatures)). For more information or to request an unlock token, please use the [LAF Access Token Request Form](https://go.microsoft.com/fwlink/?linkid=2271232&clcid=0x409).
+
+## -see-also
+
+[RemoteDesktopRegistrar](remotedesktopregistrar.md)
+
+## -examples
+
+

--- a/windows.system.remotedesktop.provider/remotedesktopregistrar_connectioncenterrequested.md
+++ b/windows.system.remotedesktop.provider/remotedesktopregistrar_connectioncenterrequested.md
@@ -12,14 +12,14 @@ public static event Windows.Foundation.EventHandler<object> ConnectionCenterRequ
 
 ## -description
 
-Raised when the user requests the boot to cloud Connection Center in a remote desktop provider app.
+Raised to notify a remote desktop provider app that the user has requested the boot to cloud Connection Center.
 
 ## -remarks
 
 Remote desktop provider apps running in the [boot to cloud](/windows-365/enterprise/windows-365-boot-overview#connection-center-at-logon) scenario should subscribe to this event to receive notifications when the user has requested the Connection Center. When the event is raised, the app should display the Connection Center UI to the user.
 
 > [!IMPORTANT]
-> The **RemoteDesktopRegistrar** API is part of a Limited Access Feature (see [LimitedAccessFeatures class](/uwp/api/windows.applicationmodel.limitedaccessfeatures)). For more information or to request an unlock token, please use the [LAF Access Token Request Form](https://go.microsoft.com/fwlink/?linkid=2271232&clcid=0x409).
+> The **ConnectionCenterRequested** event is part of a Limited Access Feature (see [LimitedAccessFeatures class](/uwp/api/windows.applicationmodel.limitedaccessfeatures)). For more information or to request an unlock token, please use the [LAF Access Token Request Form](https://go.microsoft.com/fwlink/?linkid=2271232&clcid=0x409).
 
 ## -see-also
 


### PR DESCRIPTION
## Summary

New ref topic for the `ConnectionCenterRequested` event on `RemoteDesktopRegistrar`. This event notifies remote desktop provider apps (boot to cloud scenario) when the user requests the Connection Center.

## Changes
- **New**: `remotedesktopregistrar_connectioncenterrequested.md` — event ref topic
- **Updated**: `remotedesktopregistrar.md` — added `-events` table linking to the new topic

## Notes
- Event handler signature (`EventHandler<object>`) needs confirmation from the spec: ConnectionCenterRequestedSpec.docx
- LAF token requirement carried forward from existing class doc

Fixes ADO #562869