### PR TITLE
Fix typo: evelated -> elevated in 17 files

### DIFF
--- a/windows.applicationmodel.store/currentapp_requestapppurchaseasync_2023276791.md
+++ b/windows.applicationmodel.store/currentapp_requestapppurchaseasync_2023276791.md
@@ -11,7 +11,7 @@ public Windows.Foundation.IAsyncOperation<string> RequestAppPurchaseAsync(System
 
 ## -description
 > [!IMPORTANT]
-> In-app purchase functionality is not supported in evelated applications.
+> In-app purchase functionality is not supported in elevated applications.
 
 Requests the purchase of a full app license.
 

--- a/windows.applicationmodel.store/currentapp_requestproductpurchaseasync_1631257175.md
+++ b/windows.applicationmodel.store/currentapp_requestproductpurchaseasync_1631257175.md
@@ -11,7 +11,7 @@ public Windows.Foundation.IAsyncOperation<string> RequestProductPurchaseAsync(Sy
 
 ## -description
 > [!IMPORTANT]
-> In-app purchase functionality is not supported in evelated applications.
+> In-app purchase functionality is not supported in elevated applications.
 
 > [!NOTE]
 > [RequestProductPurchaseAsync(String, Boolean) may be altered or unavailable for releases after Windows 8.1. Instead, use [RequestProductPurchaseAsync(String)](currentapp_requestproductpurchaseasync_2091240017.md).

--- a/windows.applicationmodel.store/currentapp_requestproductpurchaseasync_1934617021.md
+++ b/windows.applicationmodel.store/currentapp_requestproductpurchaseasync_1934617021.md
@@ -11,7 +11,7 @@ public Windows.Foundation.IAsyncOperation<Windows.ApplicationModel.Store.Purchas
 
 ## -description
 > [!IMPORTANT]
-> In-app purchase functionality is not supported in evelated applications.
+> In-app purchase functionality is not supported in elevated applications.
 
 Requests the purchase of an add-on (also called an in-app product or IAP). Additionally, calling this method displays the UI that is used to complete the transaction via the Microsoft Store. This overload includes parameters you can use to display details for a specific offer within a large catalog of in-app purchases that is represented by a single product entry in the Store.
 

--- a/windows.applicationmodel.store/currentapp_requestproductpurchaseasync_2091240017.md
+++ b/windows.applicationmodel.store/currentapp_requestproductpurchaseasync_2091240017.md
@@ -11,7 +11,7 @@ public Windows.Foundation.IAsyncOperation<Windows.ApplicationModel.Store.Purchas
 
 ## -description
 > [!IMPORTANT]
-> In-app purchase functionality is not supported in evelated applications.
+> In-app purchase functionality is not supported in elevated applications.
 
 Requests the purchase of an add-on (also called an in-app product or IAP). Additionally, calling this method displays the UI that is used to complete the transaction via the Microsoft Store.
 

--- a/windows.applicationmodel.store/currentappsimulator_requestapppurchaseasync_2023276791.md
+++ b/windows.applicationmodel.store/currentappsimulator_requestapppurchaseasync_2023276791.md
@@ -11,7 +11,7 @@ public Windows.Foundation.IAsyncOperation<string> RequestAppPurchaseAsync(System
 
 ## -description
 > [!IMPORTANT]
-> In-app purchase functionality is not supported in evelated applications.
+> In-app purchase functionality is not supported in elevated applications.
 
 Creates the async operation that simulates a user request to buy a full license for the current app.
 

--- a/windows.applicationmodel.store/currentappsimulator_requestproductpurchaseasync_1631257175.md
+++ b/windows.applicationmodel.store/currentappsimulator_requestproductpurchaseasync_1631257175.md
@@ -11,7 +11,7 @@ public Windows.Foundation.IAsyncOperation<string> RequestProductPurchaseAsync(Sy
 
 ## -description
 > [!IMPORTANT]
-> In-app purchase functionality is not supported in evelated applications.
+> In-app purchase functionality is not supported in elevated applications.
 
 > [!NOTE]
 > [RequestProductPurchaseAsync(String, Boolean) may be altered or unavailable for releases after Windows 8.1. Instead, use [RequestProductPurchaseAsync(String)](currentappsimulator_requestproductpurchaseasync_2091240017.md).

--- a/windows.applicationmodel.store/currentappsimulator_requestproductpurchaseasync_1934617021.md
+++ b/windows.applicationmodel.store/currentappsimulator_requestproductpurchaseasync_1934617021.md
@@ -11,7 +11,7 @@ public Windows.Foundation.IAsyncOperation<Windows.ApplicationModel.Store.Purchas
 
 ## -description
 > [!IMPORTANT]
-> In-app purchase functionality is not supported in evelated applications.
+> In-app purchase functionality is not supported in elevated applications.
 
 Creates the async operation that displays the UI that is used to simulate the purchase of an add-on (also called an in-app product or IAP) from the Microsoft Store. This overload includes parameters you can use to display details for a specific offer within a large catalog of in-app purchases that is represented by a single product entry in the Store.
 

--- a/windows.applicationmodel.store/currentappsimulator_requestproductpurchaseasync_2091240017.md
+++ b/windows.applicationmodel.store/currentappsimulator_requestproductpurchaseasync_2091240017.md
@@ -11,7 +11,7 @@ public Windows.Foundation.IAsyncOperation<Windows.ApplicationModel.Store.Purchas
 
 ## -description
 > [!IMPORTANT]
-> In-app purchase functionality is not supported in evelated applications.
+> In-app purchase functionality is not supported in elevated applications.
 
 Creates the async operation that displays the UI that is used to simulate the purchase of an add-on (also called an in-app product or IAP) from the Microsoft Store.
 

--- a/windows.services.store/storeavailability_requestpurchaseasync_1696674465.md
+++ b/windows.services.store/storeavailability_requestpurchaseasync_1696674465.md
@@ -16,7 +16,7 @@ Requests the purchase of the current SKU availability and displays the UI that i
 > This method must be called on the UI thread.
 
 > [!IMPORTANT]
-> In-app purchase functionality is not supported in evelated applications.
+> In-app purchase functionality is not supported in elevated applications.
 
 ## -returns
 An asynchronous operation that, on successful completion, returns a [StorePurchaseResult](storepurchaseresult.md) object that provides status and error info about the purchase.

--- a/windows.services.store/storeavailability_requestpurchaseasync_1703896342.md
+++ b/windows.services.store/storeavailability_requestpurchaseasync_1703896342.md
@@ -16,7 +16,7 @@ Requests the purchase of the current SKU availability and displays the UI that i
 > This method must be called on the UI thread.
 
 > [!IMPORTANT]
-> In-app purchase functionality is not supported in evelated applications.
+> In-app purchase functionality is not supported in elevated applications.
 
 ## -parameters
 ### -param storePurchaseProperties

--- a/windows.services.store/storecontext_requestpurchaseasync_1017170817.md
+++ b/windows.services.store/storecontext_requestpurchaseasync_1017170817.md
@@ -16,7 +16,7 @@ Requests the purchase for the specified app or add-on and displays the UI that i
 > This method must be called on the UI thread.
 
 > [!IMPORTANT]
-> In-app purchase functionality is not supported in evelated applications.
+> In-app purchase functionality is not supported in elevated applications.
 
 ## -parameters
 ### -param storeId

--- a/windows.services.store/storecontext_requestpurchaseasync_1039951085.md
+++ b/windows.services.store/storecontext_requestpurchaseasync_1039951085.md
@@ -16,7 +16,7 @@ Requests the purchase for the specified app or add-on and displays the UI that i
 > This method must be called on the UI thread.
 
 > [!IMPORTANT]
-> In-app purchase functionality is not supported in evelated applications.
+> In-app purchase functionality is not supported in elevated applications.
 
 ## -parameters
 ### -param storeId

--- a/windows.services.store/storecontext_requestrateandreviewappasync_2001521545.md
+++ b/windows.services.store/storecontext_requestrateandreviewappasync_2001521545.md
@@ -17,7 +17,7 @@ Requests the user to rate and review the app. This method will display the UI fo
 > This method must be called on the UI thread.
 
 > [!IMPORTANT]
-> In-app rate and review functionality is not supported in evelated applications.
+> In-app rate and review functionality is not supported in elevated applications.
 
 ## -returns
 An asynchronous operation that, on successful completion, returns a [StoreRateAndReviewResult](storerateandreviewresult.md) object that provides status and error info.

--- a/windows.services.store/storeproduct_requestpurchaseasync_1696674465.md
+++ b/windows.services.store/storeproduct_requestpurchaseasync_1696674465.md
@@ -16,7 +16,7 @@ Requests the purchase of the default SKU and availability for the product and di
 > This method must be called on the UI thread.
 
 > [!IMPORTANT]
-> In-app purchase functionality is not supported in evelated applications.
+> In-app purchase functionality is not supported in elevated applications.
 
 ## -returns
 An asynchronous operation that, on successful completion, returns a [StorePurchaseResult](storepurchaseresult.md) object that provides status and error info about the purchase.

--- a/windows.services.store/storeproduct_requestpurchaseasync_1703896342.md
+++ b/windows.services.store/storeproduct_requestpurchaseasync_1703896342.md
@@ -16,7 +16,7 @@ Requests the purchase of the default SKU and availability for the product and di
 > This method must be called on the UI thread.
 
 > [!IMPORTANT]
-> In-app purchase functionality is not supported in evelated applications.
+> In-app purchase functionality is not supported in elevated applications.
 
 ## -parameters
 ### -param storePurchaseProperties

--- a/windows.services.store/storesku_requestpurchaseasync_1696674465.md
+++ b/windows.services.store/storesku_requestpurchaseasync_1696674465.md
@@ -16,7 +16,7 @@ Requests the purchase of the product SKU and displays the UI that is used to com
 > This method must be called on the UI thread.
 
 > [!IMPORTANT]
-> In-app purchase functionality is not supported in evelated applications.
+> In-app purchase functionality is not supported in elevated applications.
 
 ## -returns
 An asynchronous operation that, on successful completion, returns a [StorePurchaseResult](storepurchaseresult.md) object that provides status and error info about the purchase.

--- a/windows.services.store/storesku_requestpurchaseasync_1703896342.md
+++ b/windows.services.store/storesku_requestpurchaseasync_1703896342.md
@@ -16,7 +16,7 @@ Requests the purchase of the product SKU and displays the UI that is used to com
 > This method must be called on the UI thread.
 
 > [!IMPORTANT]
-> In-app purchase functionality is not supported in evelated applications.
+> In-app purchase functionality is not supported in elevated applications.
 
 ## -parameters
 ### -param storePurchaseProperties


### PR DESCRIPTION
Fixes the misspelling of 'elevated' (was 'evelated') introduced in PR #2513 across all Windows.ApplicationModel.Store and Windows.Services.Store documentation files.

### Changes
- Corrected 'evelated' to 'elevated' in 17 markdown files

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>