### PR TITLE
Marking the Windows.Devices.WiFiDirect.Services Namespace as deprecated.

### DIFF
--- a/windows.devices.wifidirect.services/wifidirectservice.md
+++ b/windows.devices.wifidirect.services/wifidirectservice.md
@@ -11,6 +11,9 @@ public class WiFiDirectService : Windows.Devices.WiFiDirect.Services.IWiFiDirect
 # Windows.Devices.WiFiDirect.Services.WiFiDirectService
 
 ## -description
+> [!Important]
+> The Windows.Devices.WiFiDirect.Services Namespace is deprecated.
+
 Represents a Wi-Fi Direct service. This class is used by code on a device that seeks to use a Wi-Fi Direct Service, to establish a Wi-Fi Direct Service session with the service provider.
 
 ## -remarks

--- a/windows.devices.wifidirect.services/wifidirectservice_connectasync_1379479827.md
+++ b/windows.devices.wifidirect.services/wifidirectservice_connectasync_1379479827.md
@@ -11,7 +11,7 @@ public Windows.Foundation.IAsyncOperation<Windows.Devices.WiFiDirect.Services.Wi
 # Windows.Devices.WiFiDirect.Services.WiFiDirectService.ConnectAsync
 
 ## -description
-Initiates the establishment of a service session with the Wi-Fi Direct Service represented by this instance.
+**Deprecated.** Initiates the establishment of a service session with the Wi-Fi Direct Service represented by this instance.
 
 ## -returns
 An asynchronous connection operation. When successfully completed, returns an object that represents the session that has been established.

--- a/windows.devices.wifidirect.services/wifidirectservice_connectasync_196659251.md
+++ b/windows.devices.wifidirect.services/wifidirectservice_connectasync_196659251.md
@@ -11,7 +11,7 @@ public Windows.Foundation.IAsyncOperation<Windows.Devices.WiFiDirect.Services.Wi
 # Windows.Devices.WiFiDirect.Services.WiFiDirectService.ConnectAsync
 
 ## -description
-Initiates the establishment of a service session with the Wi-Fi Direct Service represented by this instance, using a PIN to configure the session.
+**Deprecated.** Initiates the establishment of a service session with the Wi-Fi Direct Service represented by this instance, using a PIN to configure the session.
 
 ## -parameters
 ### -param pin

--- a/windows.devices.wifidirect.services/wifidirectservice_fromidasync_1322863552.md
+++ b/windows.devices.wifidirect.services/wifidirectservice_fromidasync_1322863552.md
@@ -11,7 +11,7 @@ public Windows.Foundation.IAsyncOperation<Windows.Devices.WiFiDirect.Services.Wi
 # Windows.Devices.WiFiDirect.Services.WiFiDirectService.FromIdAsync
 
 ## -description
-Static method that retrieves a WiFiDirectService instance for a Wi-Fi Direct Service offered by the device with a given device ID.
+**Deprecated.** Static method that retrieves a WiFiDirectService instance for a Wi-Fi Direct Service offered by the device with a given device ID.
 
 ## -parameters
 ### -param deviceId

--- a/windows.devices.wifidirect.services/wifidirectservice_getprovisioninginfoasync_628266286.md
+++ b/windows.devices.wifidirect.services/wifidirectservice_getprovisioninginfoasync_628266286.md
@@ -11,7 +11,7 @@ public Windows.Foundation.IAsyncOperation<Windows.Devices.WiFiDirect.Services.Wi
 # Windows.Devices.WiFiDirect.Services.WiFiDirectService.GetProvisioningInfoAsync
 
 ## -description
-Asynchronously retrieves Wi-Fi Direct Service session provisioning information.
+**Deprecated.** Asynchronously retrieves Wi-Fi Direct Service session provisioning information.
 
 ## -parameters
 ### -param selectedConfigurationMethod

--- a/windows.devices.wifidirect.services/wifidirectservice_getselector_1490626236.md
+++ b/windows.devices.wifidirect.services/wifidirectservice_getselector_1490626236.md
@@ -11,7 +11,7 @@ public string GetSelector(System.String serviceName)
 # Windows.Devices.WiFiDirect.Services.WiFiDirectService.GetSelector
 
 ## -description
-Gets an Advanced Query Syntax (AQS) string to be used to find Wi-Fi Direct Service advertisers for a particular service.
+**Deprecated.** Gets an Advanced Query Syntax (AQS) string to be used to find Wi-Fi Direct Service advertisers for a particular service.
 
 ## -parameters
 ### -param serviceName

--- a/windows.devices.wifidirect.services/wifidirectservice_getselector_635955192.md
+++ b/windows.devices.wifidirect.services/wifidirectservice_getselector_635955192.md
@@ -11,7 +11,7 @@ public string GetSelector(System.String serviceName, Windows.Storage.Streams.IBu
 # Windows.Devices.WiFiDirect.Services.WiFiDirectService.GetSelector
 
 ## -description
-Gets an Advanced Query Syntax (AQS) string to be used to find Wi-Fi Direct Service advertisers for a particular service, where a given byte sequence appears in the advertiser's service information blob.
+**Deprecated.** Gets an Advanced Query Syntax (AQS) string to be used to find Wi-Fi Direct Service advertisers for a particular service, where a given byte sequence appears in the advertiser's service information blob.
 
 ## -parameters
 ### -param serviceName

--- a/windows.devices.wifidirect.services/wifidirectservice_prefergroupownermode.md
+++ b/windows.devices.wifidirect.services/wifidirectservice_prefergroupownermode.md
@@ -11,7 +11,7 @@ public bool PreferGroupOwnerMode { get;  set; }
 # Windows.Devices.WiFiDirect.Services.WiFiDirectService.PreferGroupOwnerMode
 
 ## -description
-Gets or sets a value specifying whether the service instance should choose Wi-Fi Direct Point to Point (P2P) Group Owner (GO) mode.
+**Deprecated.** Gets or sets a value specifying whether the service instance should choose Wi-Fi Direct Point to Point (P2P) Group Owner (GO) mode.
 
 ## -property-value
 When true, prefer GO mode.

--- a/windows.devices.wifidirect.services/wifidirectservice_remoteserviceinfo.md
+++ b/windows.devices.wifidirect.services/wifidirectservice_remoteserviceinfo.md
@@ -11,7 +11,7 @@ public Windows.Storage.Streams.IBuffer RemoteServiceInfo { get; }
 # Windows.Devices.WiFiDirect.Services.WiFiDirectService.RemoteServiceInfo
 
 ## -description
-Gets the service information blob from this service instance.
+**Deprecated.** Gets the service information blob from this service instance.
 
 ## -property-value
 A buffer of up to 255 bytes with information from the server. The format of this blob is determined by the individual service.

--- a/windows.devices.wifidirect.services/wifidirectservice_serviceerror.md
+++ b/windows.devices.wifidirect.services/wifidirectservice_serviceerror.md
@@ -11,7 +11,7 @@ public Windows.Devices.WiFiDirect.Services.WiFiDirectServiceError ServiceError {
 # Windows.Devices.WiFiDirect.Services.WiFiDirectService.ServiceError
 
 ## -description
-Error information about the latest attempt to connect to the service.
+**Deprecated.** Error information about the latest attempt to connect to the service.
 
 ## -property-value
 An enumeration value specifying the detailed reason for the failure.

--- a/windows.devices.wifidirect.services/wifidirectservice_sessiondeferred.md
+++ b/windows.devices.wifidirect.services/wifidirectservice_sessiondeferred.md
@@ -11,6 +11,7 @@ public event Windows.Foundation.TypedEventHandler SessionDeferred<Windows.Device
 # Windows.Devices.WiFiDirect.Services.WiFiDirectService.SessionDeferred
 
 ## -description
+**Deprecated.** 
 Event raised when a session request has been deferred. Note that this does not mean that the request has failed or been denied. It is a notification that the server is performing a long operation, such as waiting for a user to enter a PIN. The seeker that receives this message should begin a 120-second wait before it times out the session request, to give the server time to complete its operation. The event arguments include a buffer supplied by the server in the deferral notification with additional information.
 
 ## -remarks

--- a/windows.devices.wifidirect.services/wifidirectservice_sessioninfo.md
+++ b/windows.devices.wifidirect.services/wifidirectservice_sessioninfo.md
@@ -11,7 +11,7 @@ public Windows.Storage.Streams.IBuffer SessionInfo { get;  set; }
 # Windows.Devices.WiFiDirect.Services.WiFiDirectService.SessionInfo
 
 ## -description
-Gets or sets app-specific session information passed to the server when initiating a session.
+**Deprecated.** Gets or sets app-specific session information passed to the server when initiating a session.
 
 ## -property-value
 Session information. Format is determined by the individual service. Set this property before calling [ConnectAsync](/uwp/api/windows.devices.wifidirect.services.wifidirectservice.connectasync).

--- a/windows.devices.wifidirect.services/wifidirectservice_supportedconfigurationmethods.md
+++ b/windows.devices.wifidirect.services/wifidirectservice_supportedconfigurationmethods.md
@@ -11,7 +11,7 @@ public Windows.Foundation.Collections.IVectorView<Windows.Devices.WiFiDirect.Ser
 # Windows.Devices.WiFiDirect.Services.WiFiDirectService.SupportedConfigurationMethods
 
 ## -description
-Gets a list of supported configuration methods, ordered by preference. Your code uses [IVector](../windows.foundation.collections/ivector_1.md) operations to modify the contents of the list.
+**Deprecated.** Gets a list of supported configuration methods, ordered by preference. Your code uses [IVector](../windows.foundation.collections/ivector_1.md) operations to modify the contents of the list.
 
 ## -property-value
 Ordered list of configuration method enumeration values.

--- a/windows.devices.wifidirect.services/wifidirectserviceadvertisementstatus.md
+++ b/windows.devices.wifidirect.services/wifidirectserviceadvertisementstatus.md
@@ -11,7 +11,7 @@ public enum Windows.Devices.WiFiDirect.Services.WiFiDirectServiceAdvertisementSt
 # WiFiDirectServiceAdvertisementStatus
 
 ## -description
-Values used for [WiFiDirectServiceAdvertiser.AdvertisementStatus](wifidirectserviceadvertiser_advertisementstatus.md).
+**Deprecated.** Values used for [WiFiDirectServiceAdvertiser.AdvertisementStatus](wifidirectserviceadvertiser_advertisementstatus.md).
 
 ## -enum-fields
 ### -field Created:0

--- a/windows.devices.wifidirect.services/wifidirectserviceadvertiser.md
+++ b/windows.devices.wifidirect.services/wifidirectserviceadvertiser.md
@@ -11,7 +11,7 @@ public class WiFiDirectServiceAdvertiser : Windows.Devices.WiFiDirect.Services.I
 # Windows.Devices.WiFiDirect.Services.WiFiDirectServiceAdvertiser
 
 ## -description
-Represents a Service Advertiser. This class is used by code on a device that advertises Wi-Fi Direct Services, to advertise the service.
+**Deprecated.** Represents a Service Advertiser. This class is used by code on a device that advertises Wi-Fi Direct Services, to advertise the service.
 
 ## -remarks
 This is one of several classes that support connecting two devices with a preference for which device should be the Group Owner. See the [Windows.Devices.WiFiDirect.Service](windows_devices_wifidirect_services.md) topic for a discussion of device pairing and how it can cause the Group Owner preference to be ignored (and how to fix that.)

--- a/windows.devices.wifidirect.services/wifidirectserviceadvertiser_advertisementstatus.md
+++ b/windows.devices.wifidirect.services/wifidirectserviceadvertiser_advertisementstatus.md
@@ -11,7 +11,7 @@ public Windows.Devices.WiFiDirect.Services.WiFiDirectServiceAdvertisementStatus 
 # Windows.Devices.WiFiDirect.Services.WiFiDirectServiceAdvertiser.AdvertisementStatus
 
 ## -description
-Gets a value that describes the current status of the advertisement.
+**Deprecated.** Gets a value that describes the current status of the advertisement.
 
 ## -property-value
 An enumeration value that describes current status.

--- a/windows.devices.wifidirect.services/wifidirectserviceadvertiser_advertisementstatuschanged.md
+++ b/windows.devices.wifidirect.services/wifidirectserviceadvertiser_advertisementstatuschanged.md
@@ -11,7 +11,7 @@ public event Windows.Foundation.TypedEventHandler AdvertisementStatusChanged<Win
 # Windows.Devices.WiFiDirect.Services.WiFiDirectServiceAdvertiser.AdvertisementStatusChanged
 
 ## -description
-Event raised when the [AdvertisementStatus](wifidirectserviceadvertiser_advertisementstatus.md) property value changes.
+**Deprecated.** Event raised when the [AdvertisementStatus](wifidirectserviceadvertiser_advertisementstatus.md) property value changes.
 
 ## -remarks
 

--- a/windows.devices.wifidirect.services/wifidirectserviceadvertiser_autoacceptsession.md
+++ b/windows.devices.wifidirect.services/wifidirectserviceadvertiser_autoacceptsession.md
@@ -11,7 +11,7 @@ public bool AutoAcceptSession { get;  set; }
 # Windows.Devices.WiFiDirect.Services.WiFiDirectServiceAdvertiser.AutoAcceptSession
 
 ## -description
-Gets or sets the Auto Accept property for this service advertisement.
+**Deprecated.** Gets or sets the Auto Accept property for this service advertisement.
 
 ## -property-value
 When true, then the service automatically accepts all requests from service seekers to establish a session. If this value is false, then the service must actively accept a session request when the [SessionRequested](wifidirectserviceadvertiser_sessionrequested.md) event is raised.

--- a/windows.devices.wifidirect.services/wifidirectserviceadvertiser_autoacceptsessionconnected.md
+++ b/windows.devices.wifidirect.services/wifidirectserviceadvertiser_autoacceptsessionconnected.md
@@ -11,7 +11,7 @@ public event Windows.Foundation.TypedEventHandler AutoAcceptSessionConnected<Win
 # Windows.Devices.WiFiDirect.Services.WiFiDirectServiceAdvertiser.AutoAcceptSessionConnected
 
 ## -description
-Event raised when the service has automatically accepted a session request. Your event handler should establish socket connections for the endpoint pairs listed in the event arguments object.
+**Deprecated.** Event raised when the service has automatically accepted a session request. Your event handler should establish socket connections for the endpoint pairs listed in the event arguments object.
 
 ## -remarks
 

--- a/windows.devices.wifidirect.services/wifidirectserviceadvertiser_connectasync_2035670626.md
+++ b/windows.devices.wifidirect.services/wifidirectserviceadvertiser_connectasync_2035670626.md
@@ -11,7 +11,7 @@ public Windows.Foundation.IAsyncOperation<Windows.Devices.WiFiDirect.Services.Wi
 # Windows.Devices.WiFiDirect.Services.WiFiDirectServiceAdvertiser.ConnectAsync
 
 ## -description
-Accepts a session request by connecting with the given PIN.
+**Deprecated.** Accepts a session request by connecting with the given PIN.
 
 ## -parameters
 ### -param deviceInfo

--- a/windows.devices.wifidirect.services/wifidirectserviceadvertiser_connectasync_900322270.md
+++ b/windows.devices.wifidirect.services/wifidirectserviceadvertiser_connectasync_900322270.md
@@ -11,7 +11,7 @@ public Windows.Foundation.IAsyncOperation<Windows.Devices.WiFiDirect.Services.Wi
 # Windows.Devices.WiFiDirect.Services.WiFiDirectServiceAdvertiser.ConnectAsync
 
 ## -description
-Accepts a session request without requiring a PIN.
+**Deprecated.** Accepts a session request without requiring a PIN.
 
 ## -parameters
 ### -param deviceInfo

--- a/windows.devices.wifidirect.services/wifidirectserviceadvertiser_customservicestatuscode.md
+++ b/windows.devices.wifidirect.services/wifidirectserviceadvertiser_customservicestatuscode.md
@@ -11,7 +11,7 @@ public uint CustomServiceStatusCode { get;  set; }
 # Windows.Devices.WiFiDirect.Services.WiFiDirectServiceAdvertiser.CustomServiceStatusCode
 
 ## -description
-Gets or sets a custom service status code. Only valid if the [ServiceStatus](wifidirectserviceadvertiser_servicestatus.md) property value is **Custom**.
+**Deprecated.** Gets or sets a custom service status code. Only valid if the [ServiceStatus](wifidirectserviceadvertiser_servicestatus.md) property value is **Custom**.
 
 ## -property-value
 If [ServiceStatus](wifidirectserviceadvertiser_servicestatus.md) is set to **Custom**, this property is the custom status value. Custom values must be in the range 2 - 255.

--- a/windows.devices.wifidirect.services/wifidirectserviceadvertiser_deferredsessioninfo.md
+++ b/windows.devices.wifidirect.services/wifidirectserviceadvertiser_deferredsessioninfo.md
@@ -11,7 +11,7 @@ public Windows.Storage.Streams.IBuffer DeferredSessionInfo { get;  set; }
 # Windows.Devices.WiFiDirect.Services.WiFiDirectServiceAdvertiser.DeferredSessionInfo
 
 ## -description
-Gets or sets the service-specific information that is passed to a session requester when establishing a session will not be completed immediately, as when, for example, the service is waiting for user input to complete the request. A requester should implement a 120 second timeout when its request is deferred.
+**Deprecated.** Gets or sets the service-specific information that is passed to a session requester when establishing a session will not be completed immediately, as when, for example, the service is waiting for user input to complete the request. A requester should implement a 120 second timeout when its request is deferred.
 
 ## -property-value
 The information to be sent to the session requester. Format is service-specific, and total size cannot exceed 144 bytes.

--- a/windows.devices.wifidirect.services/wifidirectserviceadvertiser_prefergroupownermode.md
+++ b/windows.devices.wifidirect.services/wifidirectserviceadvertiser_prefergroupownermode.md
@@ -11,7 +11,7 @@ public bool PreferGroupOwnerMode { get;  set; }
 # Windows.Devices.WiFiDirect.Services.WiFiDirectServiceAdvertiser.PreferGroupOwnerMode
 
 ## -description
-Gets or sets a value indicating whether the service requires that it be the Wi-Fi Direct Peer to Peer (P2P) Group Owner.
+**Deprecated.** Gets or sets a value indicating whether the service requires that it be the Wi-Fi Direct Peer to Peer (P2P) Group Owner.
 
 Being the Group Owner enables the service to exercise more control over the P2P connection configuration and the connection process. For details, see the Wi-Fi Direct P2P Technical Specifications, available from the Wi-Fi Alliance.
 

--- a/windows.devices.wifidirect.services/wifidirectserviceadvertiser_preferredconfigurationmethods.md
+++ b/windows.devices.wifidirect.services/wifidirectserviceadvertiser_preferredconfigurationmethods.md
@@ -11,7 +11,7 @@ public Windows.Foundation.Collections.IVector<Windows.Devices.WiFiDirect.Service
 # Windows.Devices.WiFiDirect.Services.WiFiDirectServiceAdvertiser.PreferredConfigurationMethods
 
 ## -description
-Gets a list (that implements the [IVector](../windows.foundation.collections/ivector_1.md) interface) of preferred session configuration methods. Your code uses IVector operations on the list to add or remove elements from the list.
+**Deprecated.** Gets a list (that implements the [IVector](../windows.foundation.collections/ivector_1.md) interface) of preferred session configuration methods. Your code uses IVector operations on the list to add or remove elements from the list.
 
 ## -property-value
 An ordered list of enumeration values indicating preferred configuration methods. The earlier a configuration method appears in the list, the higher the preference for using that method when configuring sessions with this advertiser.

--- a/windows.devices.wifidirect.services/wifidirectserviceadvertiser_serviceerror.md
+++ b/windows.devices.wifidirect.services/wifidirectserviceadvertiser_serviceerror.md
@@ -11,7 +11,7 @@ public Windows.Devices.WiFiDirect.Services.WiFiDirectServiceError ServiceError {
 # Windows.Devices.WiFiDirect.Services.WiFiDirectServiceAdvertiser.ServiceError
 
 ## -description
-Gets a specific error code when [AdvertisementStatus](wifidirectserviceadvertiser_advertisementstatus.md) is **Aborted**.
+**Deprecated.** Gets a specific error code when [AdvertisementStatus](wifidirectserviceadvertiser_advertisementstatus.md) is **Aborted**.
 
 ## -property-value
 An enumeration value that gives a more specific cause for [AdvertisementStatus](wifidirectserviceadvertiser_advertisementstatus.md) being **Aborted**.

--- a/windows.devices.wifidirect.services/wifidirectserviceadvertiser_serviceinfo.md
+++ b/windows.devices.wifidirect.services/wifidirectserviceadvertiser_serviceinfo.md
@@ -11,7 +11,7 @@ public Windows.Storage.Streams.IBuffer ServiceInfo { get;  set; }
 # Windows.Devices.WiFiDirect.Services.WiFiDirectServiceAdvertiser.ServiceInfo
 
 ## -description
-Gets or sets the service information blob. The format and contents of the blob are determined by the individual service, and are intended to be used by Seekers during service discovery.
+**Deprecated.** Gets or sets the service information blob. The format and contents of the blob are determined by the individual service, and are intended to be used by Seekers during service discovery.
 
 ## -property-value
 The service information blob.

--- a/windows.devices.wifidirect.services/wifidirectserviceadvertiser_servicename.md
+++ b/windows.devices.wifidirect.services/wifidirectserviceadvertiser_servicename.md
@@ -11,7 +11,7 @@ public string ServiceName { get; }
 # Windows.Devices.WiFiDirect.Services.WiFiDirectServiceAdvertiser.ServiceName
 
 ## -description
-Gets the service name.
+**Deprecated.** Gets the service name.
 
 ## -property-value
 The service name.

--- a/windows.devices.wifidirect.services/wifidirectserviceadvertiser_servicenameprefixes.md
+++ b/windows.devices.wifidirect.services/wifidirectserviceadvertiser_servicenameprefixes.md
@@ -11,7 +11,7 @@ public Windows.Foundation.Collections.IVector<string> ServiceNamePrefixes { get;
 # Windows.Devices.WiFiDirect.Services.WiFiDirectServiceAdvertiser.ServiceNamePrefixes
 
 ## -description
-Gets a list of service name prefixes that should match this service when a seeker is using prefix searching. Your code uses [IVector](../windows.foundation.collections/ivector_1.md) methods to add or remove elements from the list.
+**Deprecated.** Gets a list of service name prefixes that should match this service when a seeker is using prefix searching. Your code uses [IVector](../windows.foundation.collections/ivector_1.md) methods to add or remove elements from the list.
 
 ## -property-value
 The list of prefixes. Prefix values

--- a/windows.devices.wifidirect.services/wifidirectserviceadvertiser_servicestatus.md
+++ b/windows.devices.wifidirect.services/wifidirectserviceadvertiser_servicestatus.md
@@ -11,7 +11,7 @@ public Windows.Devices.WiFiDirect.Services.WiFiDirectServiceStatus ServiceStatus
 # Windows.Devices.WiFiDirect.Services.WiFiDirectServiceAdvertiser.ServiceStatus
 
 ## -description
-Gets or sets the service status.
+**Deprecated.** Gets or sets the service status.
 
 ## -property-value
 An enumeration value that corresponds to the service status. Note that if this value is **Custom**, then the [CustomServiceStatusCode](wifidirectserviceadvertiser_customservicestatuscode.md) property gives the actual custom status code value.

--- a/windows.devices.wifidirect.services/wifidirectserviceadvertiser_sessionrequested.md
+++ b/windows.devices.wifidirect.services/wifidirectserviceadvertiser_sessionrequested.md
@@ -11,7 +11,7 @@ public event Windows.Foundation.TypedEventHandler SessionRequested<Windows.Devic
 # Windows.Devices.WiFiDirect.Services.WiFiDirectServiceAdvertiser.SessionRequested
 
 ## -description
-Event raised when a Seeker has requested that a session be established with the service associated with this WiFiDirectServiceAdvertiser instance. To accept the request, call [WiFiDirectServiceAdvertiser.ConnectAsync](/uwp/api/windows.devices.wifidirect.services.wifidirectserviceadvertiser.connectasync) in your event handler.
+**Deprecated.** Event raised when a Seeker has requested that a session be established with the service associated with this WiFiDirectServiceAdvertiser instance. To accept the request, call [WiFiDirectServiceAdvertiser.ConnectAsync](/uwp/api/windows.devices.wifidirect.services.wifidirectserviceadvertiser.connectasync) in your event handler.
 
 ## -remarks
 

--- a/windows.devices.wifidirect.services/wifidirectserviceadvertiser_start_1587696324.md
+++ b/windows.devices.wifidirect.services/wifidirectserviceadvertiser_start_1587696324.md
@@ -11,7 +11,7 @@ public void Start()
 # Windows.Devices.WiFiDirect.Services.WiFiDirectServiceAdvertiser.Start
 
 ## -description
-Starts advertising the service, using current property values to set the parameters of the advertisement.
+**Deprecated.** Starts advertising the service, using current property values to set the parameters of the advertisement.
 
 ## -remarks
 

--- a/windows.devices.wifidirect.services/wifidirectserviceadvertiser_stop_1201535524.md
+++ b/windows.devices.wifidirect.services/wifidirectserviceadvertiser_stop_1201535524.md
@@ -11,7 +11,7 @@ public void Stop()
 # Windows.Devices.WiFiDirect.Services.WiFiDirectServiceAdvertiser.Stop
 
 ## -description
-Stops advertising the service. This does not affect existing sessions that are connected to the service.
+**Deprecated.** Stops advertising the service. This does not affect existing sessions that are connected to the service.
 
 ## -remarks
 

--- a/windows.devices.wifidirect.services/wifidirectserviceadvertiser_wifidirectserviceadvertiser_290278668.md
+++ b/windows.devices.wifidirect.services/wifidirectserviceadvertiser_wifidirectserviceadvertiser_290278668.md
@@ -11,7 +11,7 @@ public WiFiDirectServiceAdvertiser(System.String serviceName)
 # Windows.Devices.WiFiDirect.Services.WiFiDirectServiceAdvertiser.WiFiDirectServiceAdvertiser
 
 ## -description
-Creates an instance of the WiFiDirectServiceAdvertiser class. To start advertising a Wi-Fi Direct Service, create an instance of this class, set its properties appropriately for your service, and then call its [Start](wifidirectserviceadvertiser_start_1587696324.md) method.
+**Deprecated.** Creates an instance of the WiFiDirectServiceAdvertiser class. To start advertising a Wi-Fi Direct Service, create an instance of this class, set its properties appropriately for your service, and then call its [Start](wifidirectserviceadvertiser_start_1587696324.md) method.
 
 ## -parameters
 ### -param serviceName

--- a/windows.devices.wifidirect.services/wifidirectserviceautoacceptsessionconnectedeventargs.md
+++ b/windows.devices.wifidirect.services/wifidirectserviceautoacceptsessionconnectedeventargs.md
@@ -11,7 +11,7 @@ public class WiFiDirectServiceAutoAcceptSessionConnectedEventArgs : Windows.Devi
 # Windows.Devices.WiFiDirect.Services.WiFiDirectServiceAutoAcceptSessionConnectedEventArgs
 
 ## -description
-Returned when a [WiFiDirectServiceAdvertiser.AutoAcceptSessionConnected](wifidirectserviceadvertiser_autoacceptsessionconnected.md) event is raised.
+**Deprecated.** Returned when a [WiFiDirectServiceAdvertiser.AutoAcceptSessionConnected](wifidirectserviceadvertiser_autoacceptsessionconnected.md) event is raised.
 
 ## -remarks
 Your code does not instantiate this class directly. An instance is passed as an argument to your [WiFiDirectServiceAdvertiser.AutoAcceptSessionConnected](wifidirectserviceadvertiser_autoacceptsessionconnected.md) event handler.

--- a/windows.devices.wifidirect.services/wifidirectserviceautoacceptsessionconnectedeventargs_session.md
+++ b/windows.devices.wifidirect.services/wifidirectserviceautoacceptsessionconnectedeventargs_session.md
@@ -11,7 +11,7 @@ public Windows.Devices.WiFiDirect.Services.WiFiDirectServiceSession Session { ge
 # Windows.Devices.WiFiDirect.Services.WiFiDirectServiceAutoAcceptSessionConnectedEventArgs.Session
 
 ## -description
-Gets the [WiFiDirectServiceSession](wifidirectservicesession.md) that was created when the connection was automatically accepted.
+**Deprecated.** Gets the [WiFiDirectServiceSession](wifidirectservicesession.md) that was created when the connection was automatically accepted.
 
 ## -property-value
 The session object corresponding to this automatically accepted connection.

--- a/windows.devices.wifidirect.services/wifidirectserviceautoacceptsessionconnectedeventargs_sessioninfo.md
+++ b/windows.devices.wifidirect.services/wifidirectserviceautoacceptsessionconnectedeventargs_sessioninfo.md
@@ -11,7 +11,7 @@ public Windows.Storage.Streams.IBuffer SessionInfo { get; }
 # Windows.Devices.WiFiDirect.Services.WiFiDirectServiceAutoAcceptSessionConnectedEventArgs.SessionInfo
 
 ## -description
-Gets the session information buffer that corresponds to this automatically accepted connection.
+**Deprecated.** Gets the session information buffer that corresponds to this automatically accepted connection.
 
 ## -property-value
 Service-specific session information, up to 144 bytes. Can be NULL if the service provides no session information.

--- a/windows.devices.wifidirect.services/wifidirectserviceconfigurationmethod.md
+++ b/windows.devices.wifidirect.services/wifidirectserviceconfigurationmethod.md
@@ -11,7 +11,7 @@ public enum Windows.Devices.WiFiDirect.Services.WiFiDirectServiceConfigurationMe
 # WiFiDirectServiceConfigurationMethod
 
 ## -description
-Values describing how service configuration is performed when a session is being established. Typically, either no input is required, or one device in the session displays a PIN and the other device requires that the PIN be entered.
+**Deprecated.** Values describing how service configuration is performed when a session is being established. Typically, either no input is required, or one device in the session displays a PIN and the other device requires that the PIN be entered.
 
 ## -enum-fields
 ### -field Default:0

--- a/windows.devices.wifidirect.services/wifidirectserviceerror.md
+++ b/windows.devices.wifidirect.services/wifidirectserviceerror.md
@@ -11,7 +11,7 @@ public enum Windows.Devices.WiFiDirect.Services.WiFiDirectServiceError : int
 # WiFiDirectServiceError
 
 ## -description
-Values used for the [WiFiDirectServiceAdvertiser.ServiceError](wifidirectserviceadvertiser_serviceerror.md) property.
+**Deprecated.** Values used for the [WiFiDirectServiceAdvertiser.ServiceError](wifidirectserviceadvertiser_serviceerror.md) property.
 
 ## -enum-fields
 ### -field Success:0

--- a/windows.devices.wifidirect.services/wifidirectserviceipprotocol.md
+++ b/windows.devices.wifidirect.services/wifidirectserviceipprotocol.md
@@ -11,7 +11,7 @@ public enum Windows.Devices.WiFiDirect.Services.WiFiDirectServiceIPProtocol : in
 # WiFiDirectServiceIPProtocol
 
 ## -description
-Defines constants that specify the IP protocol of the new port when a [WiFiDirectServiceSession.RemotePortAdded](wifidirectservicesession_remoteportadded.md) event is raised.
+**Deprecated.** Defines constants that specify the IP protocol of the new port when a [WiFiDirectServiceSession.RemotePortAdded](wifidirectservicesession_remoteportadded.md) event is raised.
 
 ## -enum-fields
 

--- a/windows.devices.wifidirect.services/wifidirectserviceprovisioninginfo.md
+++ b/windows.devices.wifidirect.services/wifidirectserviceprovisioninginfo.md
@@ -11,7 +11,7 @@ public class WiFiDirectServiceProvisioningInfo : Windows.Devices.WiFiDirect.Serv
 # Windows.Devices.WiFiDirect.Services.WiFiDirectServiceProvisioningInfo
 
 ## -description
-Contains provisioning information about a Wi-Fi Direct Service.
+**Deprecated.** Contains provisioning information about a Wi-Fi Direct Service.
 
 ## -remarks
 Your code does not instantiate this class directly. You can retrieve an instance using either the [WiFiDirectServiceSessionRequest.ProvisioningInfo](wifidirectservicesessionrequest_provisioninginfo.md) property or the [WiFiDirectService.GetProvisioningInfoAsync](wifidirectservice_getprovisioninginfoasync_628266286.md) method.

--- a/windows.devices.wifidirect.services/wifidirectserviceprovisioninginfo_isgroupformationneeded.md
+++ b/windows.devices.wifidirect.services/wifidirectserviceprovisioninginfo_isgroupformationneeded.md
@@ -11,7 +11,7 @@ public bool IsGroupFormationNeeded { get; }
 # Windows.Devices.WiFiDirect.Services.WiFiDirectServiceProvisioningInfo.IsGroupFormationNeeded
 
 ## -description
-Gets a value indicating whether Wi-Fi Direct Point to Point (P2P) group formation is needed.
+**Deprecated.** Gets a value indicating whether Wi-Fi Direct Point to Point (P2P) group formation is needed.
 
 ## -property-value
 When true, group formation is needed.

--- a/windows.devices.wifidirect.services/wifidirectserviceprovisioninginfo_selectedconfigurationmethod.md
+++ b/windows.devices.wifidirect.services/wifidirectserviceprovisioninginfo_selectedconfigurationmethod.md
@@ -11,7 +11,7 @@ public Windows.Devices.WiFiDirect.Services.WiFiDirectServiceConfigurationMethod 
 # Windows.Devices.WiFiDirect.Services.WiFiDirectServiceProvisioningInfo.SelectedConfigurationMethod
 
 ## -description
-Gets a value describing the configuration method in use.
+**Deprecated.** Gets a value describing the configuration method in use.
 
 ## -property-value
 Enumeration value representing the configuration method in use.

--- a/windows.devices.wifidirect.services/wifidirectserviceremoteportaddedeventargs.md
+++ b/windows.devices.wifidirect.services/wifidirectserviceremoteportaddedeventargs.md
@@ -11,7 +11,7 @@ public class WiFiDirectServiceRemotePortAddedEventArgs : Windows.Devices.WiFiDir
 # Windows.Devices.WiFiDirect.Services.WiFiDirectServiceRemotePortAddedEventArgs
 
 ## -description
-Returned when a [WiFiDirectServiceSession.RemotePortAdded](wifidirectservicesession_remoteportadded.md) event is raised. Your event handler should use this information to establish new socket connections to the new port.
+**Deprecated.** Returned when a [WiFiDirectServiceSession.RemotePortAdded](wifidirectservicesession_remoteportadded.md) event is raised. Your event handler should use this information to establish new socket connections to the new port.
 
 ## -remarks
 Your code does not instantiate this class directly. An instance is passed as an argument to your [WiFiDirectServiceSession.RemotePortAdded](wifidirectservicesession_remoteportadded.md) event handler.

--- a/windows.devices.wifidirect.services/wifidirectserviceremoteportaddedeventargs_endpointpairs.md
+++ b/windows.devices.wifidirect.services/wifidirectserviceremoteportaddedeventargs_endpointpairs.md
@@ -11,7 +11,7 @@ public Windows.Foundation.Collections.IVectorView<Windows.Networking.EndpointPai
 # Windows.Devices.WiFiDirect.Services.WiFiDirectServiceRemotePortAddedEventArgs.EndpointPairs
 
 ## -description
-Gets the endpoint pairs associated with the new remote port.
+**Deprecated.** Gets the endpoint pairs associated with the new remote port.
 
 ## -property-value
 New endpoint pairs.

--- a/windows.devices.wifidirect.services/wifidirectserviceremoteportaddedeventargs_protocol.md
+++ b/windows.devices.wifidirect.services/wifidirectserviceremoteportaddedeventargs_protocol.md
@@ -11,7 +11,7 @@ public Windows.Devices.WiFiDirect.Services.WiFiDirectServiceIPProtocol Protocol 
 # Windows.Devices.WiFiDirect.Services.WiFiDirectServiceRemotePortAddedEventArgs.Protocol
 
 ## -description
-Gets the protocol used to communicate with the new remote port.
+**Deprecated.** Gets the protocol used to communicate with the new remote port.
 
 ## -property-value
 An enumeration value corresponding to the IP protocol to use for the new remote port.

--- a/windows.devices.wifidirect.services/wifidirectservicesession.md
+++ b/windows.devices.wifidirect.services/wifidirectservicesession.md
@@ -11,7 +11,7 @@ public class WiFiDirectServiceSession : Windows.Devices.WiFiDirect.Services.IWiF
 # Windows.Devices.WiFiDirect.Services.WiFiDirectServiceSession
 
 ## -description
-Represents a Wi-Fi Direct Services (WFDS) session.
+**Deprecated.** Represents a Wi-Fi Direct Services (WFDS) session.
 
 ## -remarks
 Your code does not instantiate this class directly. An instance is created and passed to your code in event handlers when a new session is created or session state changes.

--- a/windows.devices.wifidirect.services/wifidirectservicesession_adddatagramsocketasync_903878578.md
+++ b/windows.devices.wifidirect.services/wifidirectservicesession_adddatagramsocketasync_903878578.md
@@ -11,7 +11,7 @@ public Windows.Foundation.IAsyncAction AddDatagramSocketAsync(Windows.Networking
 # Windows.Devices.WiFiDirect.Services.WiFiDirectServiceSession.AddDatagramSocketAsync
 
 ## -description
-Adds a [DatagramSocket](../windows.networking.sockets/datagramsocket.md) to the session. Your code creates the DatagramSocket before calling this method. Associating a socket to the session causes port information to be sent to the remote device(s) in the session. (In terms of this API, a [RemotePortAdded](wifidirectservicesession_remoteportadded.md) event is raised on each remote device in the session, specifying the UDP protocol.) A remote device can use that information to open a socket and connect back to the local machine.
+**Deprecated.** Adds a [DatagramSocket](../windows.networking.sockets/datagramsocket.md) to the session. Your code creates the DatagramSocket before calling this method. Associating a socket to the session causes port information to be sent to the remote device(s) in the session. (In terms of this API, a [RemotePortAdded](wifidirectservicesession_remoteportadded.md) event is raised on each remote device in the session, specifying the UDP protocol.) A remote device can use that information to open a socket and connect back to the local machine.
 
 ## -parameters
 ### -param value

--- a/windows.devices.wifidirect.services/wifidirectservicesession_addstreamsocketlistenerasync_1369574118.md
+++ b/windows.devices.wifidirect.services/wifidirectservicesession_addstreamsocketlistenerasync_1369574118.md
@@ -11,7 +11,7 @@ public Windows.Foundation.IAsyncAction AddStreamSocketListenerAsync(Windows.Netw
 # Windows.Devices.WiFiDirect.Services.WiFiDirectServiceSession.AddStreamSocketListenerAsync
 
 ## -description
-Adds a [StreamSocketListener](../windows.networking.sockets/streamsocketlistener.md) to the session. Your code creates the StreamSocketListener before calling this method. Associating a socket to the session causes port information to be sent to the remote device(s) in the session. (In terms of this API, a [RemotePortAdded](wifidirectservicesession_remoteportadded.md) event is raised on each remote device in the session, specifying the TCP protocol.) A remote device can use that information to open a socket and connect back to the local machine.
+**Deprecated.** Adds a [StreamSocketListener](../windows.networking.sockets/streamsocketlistener.md) to the session. Your code creates the StreamSocketListener before calling this method. Associating a socket to the session causes port information to be sent to the remote device(s) in the session. (In terms of this API, a [RemotePortAdded](wifidirectservicesession_remoteportadded.md) event is raised on each remote device in the session, specifying the TCP protocol.) A remote device can use that information to open a socket and connect back to the local machine.
 
 ## -parameters
 ### -param value

--- a/windows.devices.wifidirect.services/wifidirectservicesession_advertisementid.md
+++ b/windows.devices.wifidirect.services/wifidirectservicesession_advertisementid.md
@@ -11,7 +11,7 @@ public uint AdvertisementId { get; }
 # Windows.Devices.WiFiDirect.Services.WiFiDirectServiceSession.AdvertisementId
 
 ## -description
-Gets the advertisement ID for the session.
+**Deprecated.** Gets the advertisement ID for the session.
 
 ## -property-value
 The advertisement ID.

--- a/windows.devices.wifidirect.services/wifidirectservicesession_close_811482585.md
+++ b/windows.devices.wifidirect.services/wifidirectservicesession_close_811482585.md
@@ -11,7 +11,7 @@ public void Close()
 # Windows.Devices.WiFiDirect.Services.WiFiDirectServiceSession.Close
 
 ## -description
-Closes the session.
+**Deprecated.** Closes the session.
 
 ## -remarks
 

--- a/windows.devices.wifidirect.services/wifidirectservicesession_errorstatus.md
+++ b/windows.devices.wifidirect.services/wifidirectservicesession_errorstatus.md
@@ -11,7 +11,7 @@ public Windows.Devices.WiFiDirect.Services.WiFiDirectServiceSessionErrorStatus E
 # Windows.Devices.WiFiDirect.Services.WiFiDirectServiceSession.ErrorStatus
 
 ## -description
-Gets the error status of the session.
+**Deprecated.** Gets the error status of the session.
 
 ## -property-value
 An enumeration value giving session error status.

--- a/windows.devices.wifidirect.services/wifidirectservicesession_getconnectionendpointpairs_1958888015.md
+++ b/windows.devices.wifidirect.services/wifidirectservicesession_getconnectionendpointpairs_1958888015.md
@@ -11,7 +11,7 @@ public Windows.Foundation.Collections.IVectorView<Windows.Networking.EndpointPai
 # Windows.Devices.WiFiDirect.Services.WiFiDirectServiceSession.GetConnectionEndpointPairs
 
 ## -description
-Gets a list of connection endpoint pairs for the session. Your code uses [IVectorView](../windows.foundation.collections/ivectorview_1.md) operations to enumerate the endpoint pairs in the list.
+**Deprecated.** Gets a list of connection endpoint pairs for the session. Your code uses [IVectorView](../windows.foundation.collections/ivectorview_1.md) operations to enumerate the endpoint pairs in the list.
 
 ## -returns
 An immutable snapshot list of endpoint pairs involved in the session.

--- a/windows.devices.wifidirect.services/wifidirectservicesession_remoteportadded.md
+++ b/windows.devices.wifidirect.services/wifidirectservicesession_remoteportadded.md
@@ -11,7 +11,7 @@ public event Windows.Foundation.TypedEventHandler RemotePortAdded<Windows.Device
 # Windows.Devices.WiFiDirect.Services.WiFiDirectServiceSession.RemotePortAdded
 
 ## -description
-Event raised when a new remote port is added to the session. Your event handler should respond by establishing the appropriate socket connection to the new remote port.
+**Deprecated.** Event raised when a new remote port is added to the session. Your event handler should respond by establishing the appropriate socket connection to the new remote port.
 
 ## -remarks
 

--- a/windows.devices.wifidirect.services/wifidirectservicesession_serviceaddress.md
+++ b/windows.devices.wifidirect.services/wifidirectservicesession_serviceaddress.md
@@ -11,7 +11,7 @@ public string ServiceAddress { get; }
 # Windows.Devices.WiFiDirect.Services.WiFiDirectServiceSession.ServiceAddress
 
 ## -description
-Gets the service address for this session.
+**Deprecated.** Gets the service address for this session.
 
 ## -property-value
 The service address.

--- a/windows.devices.wifidirect.services/wifidirectservicesession_servicename.md
+++ b/windows.devices.wifidirect.services/wifidirectservicesession_servicename.md
@@ -11,7 +11,7 @@ public string ServiceName { get; }
 # Windows.Devices.WiFiDirect.Services.WiFiDirectServiceSession.ServiceName
 
 ## -description
-Gets the service name of the advertiser service involved in the session.
+**Deprecated.** Gets the service name of the advertiser service involved in the session.
 
 ## -property-value
 The service name of the advertiser service.

--- a/windows.devices.wifidirect.services/wifidirectservicesession_sessionaddress.md
+++ b/windows.devices.wifidirect.services/wifidirectservicesession_sessionaddress.md
@@ -11,7 +11,7 @@ public string SessionAddress { get; }
 # Windows.Devices.WiFiDirect.Services.WiFiDirectServiceSession.SessionAddress
 
 ## -description
-Gets the session address for the session.
+**Deprecated.** Gets the session address for the session.
 
 ## -property-value
 The session address.

--- a/windows.devices.wifidirect.services/wifidirectservicesession_sessionid.md
+++ b/windows.devices.wifidirect.services/wifidirectservicesession_sessionid.md
@@ -11,7 +11,7 @@ public uint SessionId { get; }
 # Windows.Devices.WiFiDirect.Services.WiFiDirectServiceSession.SessionId
 
 ## -description
-Gets the session ID.
+**Deprecated.** Gets the session ID.
 
 ## -property-value
 A unique session identifier.

--- a/windows.devices.wifidirect.services/wifidirectservicesession_sessionstatuschanged.md
+++ b/windows.devices.wifidirect.services/wifidirectservicesession_sessionstatuschanged.md
@@ -11,7 +11,7 @@ public event Windows.Foundation.TypedEventHandler SessionStatusChanged<Windows.D
 # Windows.Devices.WiFiDirect.Services.WiFiDirectServiceSession.SessionStatusChanged
 
 ## -description
-Event raised when the session status changes.
+**Deprecated.** Event raised when the session status changes.
 
 ## -remarks
 

--- a/windows.devices.wifidirect.services/wifidirectservicesession_status.md
+++ b/windows.devices.wifidirect.services/wifidirectservicesession_status.md
@@ -11,7 +11,7 @@ public Windows.Devices.WiFiDirect.Services.WiFiDirectServiceSessionStatus Status
 # Windows.Devices.WiFiDirect.Services.WiFiDirectServiceSession.Status
 
 ## -description
-Gets the session status.
+**Deprecated.** Gets the session status.
 
 ## -property-value
 An enumeration value describing the current session status.

--- a/windows.devices.wifidirect.services/wifidirectservicesessiondeferredeventargs.md
+++ b/windows.devices.wifidirect.services/wifidirectservicesessiondeferredeventargs.md
@@ -11,7 +11,7 @@ public class WiFiDirectServiceSessionDeferredEventArgs : Windows.Devices.WiFiDir
 # Windows.Devices.WiFiDirect.Services.WiFiDirectServiceSessionDeferredEventArgs
 
 ## -description
-Returned when a [WiFiDirectService.SessionDeferred](wifidirectservice_sessiondeferred.md) event is raised.
+**Deprecated.** Returned when a [WiFiDirectService.SessionDeferred](wifidirectservice_sessiondeferred.md) event is raised.
 
 ## -remarks
 Your code does not instantiate this class directly. An instance of this class is passed as an argument to your [WiFiDirectService.SessionDeferred](wifidirectservice_sessiondeferred.md) event handler.

--- a/windows.devices.wifidirect.services/wifidirectservicesessiondeferredeventargs_deferredsessioninfo.md
+++ b/windows.devices.wifidirect.services/wifidirectservicesessiondeferredeventargs_deferredsessioninfo.md
@@ -11,7 +11,7 @@ public Windows.Storage.Streams.IBuffer DeferredSessionInfo { get; }
 # Windows.Devices.WiFiDirect.Services.WiFiDirectServiceSessionDeferredEventArgs.DeferredSessionInfo
 
 ## -description
-Gets the service-defined session information returned by the service when it sends a deferral in response to a connection request. Note that a deferral does not indicate that the connection is refused. Rather, it indicates that the server is performing a time-consuming operation such as requesting user input. A seeker should implement a 120-second timeout after getting a deferral before giving up on the request.
+**Deprecated.** Gets the service-defined session information returned by the service when it sends a deferral in response to a connection request. Note that a deferral does not indicate that the connection is refused. Rather, it indicates that the server is performing a time-consuming operation such as requesting user input. A seeker should implement a 120-second timeout after getting a deferral before giving up on the request.
 
 ## -property-value
 A byte sequence of deferred session information, up to 144 bytes. Format is defined by the service.

--- a/windows.devices.wifidirect.services/wifidirectservicesessionerrorstatus.md
+++ b/windows.devices.wifidirect.services/wifidirectservicesessionerrorstatus.md
@@ -11,7 +11,7 @@ public enum Windows.Devices.WiFiDirect.Services.WiFiDirectServiceSessionErrorSta
 # WiFiDirectServiceSessionErrorStatus
 
 ## -description
-Values used in the [WiFiDirectServiceSession.ErrorStatus](wifidirectservicesession_errorstatus.md) property.
+**Deprecated.** Values used in the [WiFiDirectServiceSession.ErrorStatus](wifidirectservicesession_errorstatus.md) property.
 
 ## -enum-fields
 ### -field Ok:0

--- a/windows.devices.wifidirect.services/wifidirectservicesessionrequest.md
+++ b/windows.devices.wifidirect.services/wifidirectservicesessionrequest.md
@@ -11,7 +11,7 @@ public class WiFiDirectServiceSessionRequest : Windows.Devices.WiFiDirect.Servic
 # Windows.Devices.WiFiDirect.Services.WiFiDirectServiceSessionRequest
 
 ## -description
-Describes a Wi-Fi Direct Service session request.
+**Deprecated.** Describes a Wi-Fi Direct Service session request.
 
 ## -remarks
 Your code does not instantiate this class directly. An instance of this class is inside the [WiFiDirectServiceSessionRequestedEventArgs](wifidirectservicesessionrequestedeventargs.md) object passed to your [WiFiDirectServiceAdvertiser.SessionRequested](wifidirectserviceadvertiser_sessionrequested.md) event handler.

--- a/windows.devices.wifidirect.services/wifidirectservicesessionrequest_close_811482585.md
+++ b/windows.devices.wifidirect.services/wifidirectservicesessionrequest_close_811482585.md
@@ -11,7 +11,7 @@ public void Close()
 # Windows.Devices.WiFiDirect.Services.WiFiDirectServiceSessionRequest.Close
 
 ## -description
-Closes the session request. Your server code calls this method to reject a session request.
+**Deprecated.** Closes the session request. Your server code calls this method to reject a session request.
 
 ## -remarks
 

--- a/windows.devices.wifidirect.services/wifidirectservicesessionrequest_deviceinformation.md
+++ b/windows.devices.wifidirect.services/wifidirectservicesessionrequest_deviceinformation.md
@@ -11,7 +11,7 @@ public Windows.Devices.Enumeration.DeviceInformation DeviceInformation { get; }
 # Windows.Devices.WiFiDirect.Services.WiFiDirectServiceSessionRequest.DeviceInformation
 
 ## -description
-Gets device information for the requesting device.
+**Deprecated.** Gets device information for the requesting device.
 
 ## -property-value
 Describes the requesting device.

--- a/windows.devices.wifidirect.services/wifidirectservicesessionrequest_provisioninginfo.md
+++ b/windows.devices.wifidirect.services/wifidirectservicesessionrequest_provisioninginfo.md
@@ -11,7 +11,7 @@ public Windows.Devices.WiFiDirect.Services.WiFiDirectServiceProvisioningInfo Pro
 # Windows.Devices.WiFiDirect.Services.WiFiDirectServiceSessionRequest.ProvisioningInfo
 
 ## -description
-Gets information about how provisioning should be performed if the session is established.
+**Deprecated.** Gets information about how provisioning should be performed if the session is established.
 
 ## -property-value
 Provisioning information.

--- a/windows.devices.wifidirect.services/wifidirectservicesessionrequest_sessioninfo.md
+++ b/windows.devices.wifidirect.services/wifidirectservicesessionrequest_sessioninfo.md
@@ -11,7 +11,7 @@ public Windows.Storage.Streams.IBuffer SessionInfo { get; }
 # Windows.Devices.WiFiDirect.Services.WiFiDirectServiceSessionRequest.SessionInfo
 
 ## -description
-Gets the session information blob associated with this request.
+**Deprecated.** Gets the session information blob associated with this request.
 
 ## -property-value
 A byte sequence, up to 144 bytes. The format is defined by the service.

--- a/windows.devices.wifidirect.services/wifidirectservicesessionrequestedeventargs.md
+++ b/windows.devices.wifidirect.services/wifidirectservicesessionrequestedeventargs.md
@@ -11,7 +11,7 @@ public class WiFiDirectServiceSessionRequestedEventArgs : Windows.Devices.WiFiDi
 # Windows.Devices.WiFiDirect.Services.WiFiDirectServiceSessionRequestedEventArgs
 
 ## -description
-Returned when a [WiFiDirectServiceAdvertiser.SessionRequested](wifidirectserviceadvertiser_sessionrequested.md) event is raised.
+**Deprecated.** Returned when a [WiFiDirectServiceAdvertiser.SessionRequested](wifidirectserviceadvertiser_sessionrequested.md) event is raised.
 
 ## -remarks
 Your code does not instantiate this class directly. An instance is passed as an argument to your [WiFiDirectServiceAdvertiser.SessionRequested](wifidirectserviceadvertiser_sessionrequested.md) event handler.

--- a/windows.devices.wifidirect.services/wifidirectservicesessionrequestedeventargs_getsessionrequest_1327265926.md
+++ b/windows.devices.wifidirect.services/wifidirectservicesessionrequestedeventargs_getsessionrequest_1327265926.md
@@ -11,7 +11,7 @@ public Windows.Devices.WiFiDirect.Services.WiFiDirectServiceSessionRequest GetSe
 # Windows.Devices.WiFiDirect.Services.WiFiDirectServiceSessionRequestedEventArgs.GetSessionRequest
 
 ## -description
-Gets information about the session request that raised a [WiFiDirectServiceAdvertiser.SessionRequested](wifidirectserviceadvertiser_sessionrequested.md) event.
+**Deprecated.** Gets information about the session request that raised a [WiFiDirectServiceAdvertiser.SessionRequested](wifidirectserviceadvertiser_sessionrequested.md) event.
 
 ## -returns
 Information about a new session request.

--- a/windows.devices.wifidirect.services/wifidirectservicesessionstatus.md
+++ b/windows.devices.wifidirect.services/wifidirectservicesessionstatus.md
@@ -11,7 +11,7 @@ public enum Windows.Devices.WiFiDirect.Services.WiFiDirectServiceSessionStatus :
 # WiFiDirectServiceSessionStatus
 
 ## -description
-Values used to describe the status of a Wi-Fi Direct Service Session.
+**Deprecated.** Values used to describe the status of a Wi-Fi Direct Service Session.
 
 ## -enum-fields
 ### -field Closed:0

--- a/windows.devices.wifidirect.services/wifidirectservicestatus.md
+++ b/windows.devices.wifidirect.services/wifidirectservicestatus.md
@@ -11,7 +11,7 @@ public enum Windows.Devices.WiFiDirect.Services.WiFiDirectServiceStatus : int
 # WiFiDirectServiceStatus
 
 ## -description
-Values used to describe the service status.
+**Deprecated.** Values used to describe the service status.
 
 ## -enum-fields
 ### -field Available:0

--- a/windows.devices.wifidirect.services/windows_devices_wifidirect_services.md
+++ b/windows.devices.wifidirect.services/windows_devices_wifidirect_services.md
@@ -6,6 +6,8 @@
 # Windows.Devices.WiFiDirect.Services
 
 ## -description
+> [!Important]
+> The Windows.Devices.WiFiDirect.Services Namespace is deprecated.
 
 Provides support for implementing your own Wi-Fi Direct Services.
 


### PR DESCRIPTION
Marking the Windows.Devices.WiFiDirect.Services Namespace as deprecated.
Plan signed off by winremove.