### PR TITLE
Correctly escape angle bracket inside link

### DIFF
--- a/windows.foundation.collections/ivector_1.md
+++ b/windows.foundation.collections/ivector_1.md
@@ -47,4 +47,4 @@ IVector inherits [IIterable](iiterable_1.md). Types that implement IVector also 
 
 ## -see-also
 
-[Collections (C++/CX)](/cpp/cppcx/collections-c-cx), [System.Collections.Generic.IList\<T\>](/dotnet/api/system.collections.generic.ilist-1)
+[Collections (C++/CX)](/cpp/cppcx/collections-c-cx), [System.Collections.Generic.IList&lt;T&gt;](/dotnet/api/system.collections.generic.ilist-1)


### PR DESCRIPTION
- Link to the affected doc: https://learn.microsoft.com/en-us/uwp/api/windows.foundation.collections.ivector-1
- For reference, correct usage: https://github.com/MicrosoftDocs/winrt-api/blob/783edf4c4ba54c4239bd405f396f7cdf40eb4639/windows.foundation.collections/iobservablevector_1.md?plain=1#L31