### PR TITLE
Document retail license requirement for StoreContext APIs

### DIFF
--- a/windows.services.store/storecontext.md
+++ b/windows.services.store/storecontext.md
@@ -19,6 +19,9 @@ In a desktop app, before using an instance of this class in a way that displays 
 > [!NOTE]
 > This class and the rest of the [Windows.Services.Store](windows_services_store.md) namespace was introduced in Windows 10, version 1607. This class can only be used in projects that target **Windows 10 Anniversary Edition (10.0; Build 14393)** or a later release in Visual Studio. If your project targets an earlier version of Windows 10, you must use the [Windows.ApplicationModel.Store](../windows.applicationmodel.store/windows_applicationmodel_store.md) namespace instead of the [Windows.Services.Store](windows_services_store.md) namespace. For more information, see [In-app purchases and trials](/windows/uwp/monetize/in-app-purchases-and-trials).
 
+> [!IMPORTANT]
+> StoreContext APIs require that the calling app has a valid retail license issued by the Microsoft Store. Other license states (unlicensed, developer license, etc.) are not supported and may result in unexpected errors or application crashes.
+
 The StoreContext class is the main entry point to the [Windows.Services.Store](windows_services_store.md) namespace. Use members of this class to perform tasks such as getting Microsoft Store listing and license info for the current app, purchasing the current app or add-ons that are offered by the app, or downloading and installing package updates for the app. Other classes and types in this namespace represent items such as add-ons for the app, licenses for the app and its add-ons, and Microsoft Store listing info for the app.
 
 To get a StoreContext object, use one of these static methods:

--- a/windows.services.store/windows_services_store.md
+++ b/windows.services.store/windows_services_store.md
@@ -11,6 +11,9 @@ Provides types and members you can use to access and manage Microsoft Store-rela
 > [!IMPORTANT]
 > In-app purchase and in-app rate and review functionalities are not currently supported in elevated applications.
 
+> [!IMPORTANT]
+> APIs in this namespace require that the calling app has a valid retail license issued by the Microsoft Store. Other license states (unlicensed, developer license, etc.) are not supported and may result in unexpected errors or application crashes.
+
 > [!NOTE]
 > This namespace was introduced in Windows 10, version 1607, and it can only be used in projects that target **Windows 10 Anniversary Edition (10.0; Build 14393)** or a later release in Visual Studio. If your project targets an earlier version of Windows 10, you must use the [Windows.ApplicationModel.Store](../windows.applicationmodel.store/windows_applicationmodel_store.md) namespace instead of the Windows.Services.Store namespace. For more information, see [In-app purchases and trials](/windows/uwp/monetize/in-app-purchases-and-trials).
 


### PR DESCRIPTION
## Summary

Documents that StoreContext APIs in the `Windows.Services.Store` namespace require a valid **retail license** issued by the Microsoft Store. A developer license (obtained through Developer Mode or Visual Studio sideloading) is **not** a valid license for StoreContext operations and can cause unexpected errors or application crashes.

## Motivation

Internal teams (e.g., M365 Copilot) have been attempting to use StoreContext with developer licenses. The SDK can crash when a dev license is used instead of a retail license, and this is not documented anywhere in the public API reference. This has caused confusion and difficult-to-diagnose failures.

## Changes

Added `[!IMPORTANT]` callout notes to:
- **`windows.services.store/storecontext.md`** — class-level documentation
- **`windows.services.store/windows_services_store.md`** — namespace-level documentation

Both notes clearly state:
1. A valid retail license is required
2. Developer licenses are not valid for StoreContext
3. API calls without a retail license may error or crash

## Related

- [StoreContext Class - Microsoft Learn](https://learn.microsoft.com/en-us/uwp/api/windows.services.store.storecontext)
- [In-app purchases and trials](https://learn.microsoft.com/en-us/windows/uwp/monetize/in-app-purchases-and-trials)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>