### PR TITLE
Document LoadedImageSurface 2340px desiredMaxSize threshold

### DIFF
--- a/windows.ui.xaml.media/loadedimagesurface.md
+++ b/windows.ui.xaml.media/loadedimagesurface.md
@@ -41,6 +41,18 @@ no max size is specified, then the image will decode to its natural size.
 * [StartLoadFromStream(IRandomAccessStream)](loadedimagesurface_startloadfromstream_1253534602.md)
 * [StartLoadFromStream(IRandomAccessStream, Size)](loadedimagesurface_startloadfromstream_1850726798.md)
 
+### Surface allocation and the desiredMaxSize threshold
+
+When you specify a `desiredMaxSize`, the system uses it to determine the surface allocation strategy:
+
+- **desiredMaxSize ≤ 2340 pixels** (per dimension): The surface is allocated as a non-virtual (performance-optimized) hardware surface. The image decodes up to `desiredMaxSize × currentDPIScale`, capped at approximately 16,380 pixels. This path is faster for typical UI images.
+- **desiredMaxSize > 2340 pixels** (per dimension): The surface is allocated as a virtual surface, which supports resizing up to the hardware texture limit (typically 16,384 pixels per dimension). Initial allocation is slower but allows larger images.
+
+The 2340-pixel threshold is derived from the maximum hardware texture size (16,384) divided by the maximum supported DPI scale factor (7). If you pass a `desiredMaxSize` between 2340 and 16,384 pixels expecting the image to decode at exactly that resolution on a non-virtual surface, the image may be downscaled without warning. To ensure full-resolution decoding for large images, pass a `desiredMaxSize` greater than 2340 pixels per dimension so a virtual surface is allocated.
+
+> [!NOTE]
+> The maximum hardware texture size (16,384 pixels) is determined by the graphics hardware and DirectComposition. The 2340-pixel threshold is an internal optimization heuristic and may change in future Windows releases.
+
 ### Lifetime management
 When a **LoadedImageSurface** is created using one of the factory methods, the underlying surface is immediately initialized to a size of 0x0 and the image content begins
 downloading and decoding off of the UI thread. When the image source has been successfully decoded, it then gets loaded onto the surface and the [LoadCompleted](loadedimagesurface_loadcompleted.md) event gets fired

--- a/windows.ui.xaml.media/loadedimagesurface_startloadfromstream_1850726798.md
+++ b/windows.ui.xaml.media/loadedimagesurface_startloadfromstream_1850726798.md
@@ -32,8 +32,9 @@ An instance of [LoadedImageSurface](loadedimagesurface.md) with the image loaded
 
 ## -remarks
 
-By default, [LoadedImageSurface](loadedimagesurface.md) will fill up as much of the **desiredMaxSize** as possible while preserving the aspect ratio and image content
-of the incoming source. This may result in a decodedsize that differs from the input **desiredMaxSize**
+By default, [LoadedImageSurface](loadedimagesurface.md) will fill up as much of the **desiredMaxSize** as possible while preserving the aspect ratio and image content of the incoming source. This may result in a decoded size that differs from the input **desiredMaxSize**.
+
+The **desiredMaxSize** parameter also determines the surface allocation strategy. If either dimension of **desiredMaxSize** is 2340 pixels or less, the system allocates a non-virtual (performance-optimized) surface where the effective decode resolution is capped at `desiredMaxSize × currentDPIScale` (up to approximately 16,380 pixels). If either dimension exceeds 2340 pixels, a virtual surface is allocated that supports the full hardware texture limit (typically 16,384 pixels per dimension). For more information, see [LoadedImageSurface remarks](loadedimagesurface.md#surface-allocation-and-the-desiredmaxsize-threshold).
 
 ## -see-also
 

--- a/windows.ui.xaml.media/loadedimagesurface_startloadfromuri_2119955733.md
+++ b/windows.ui.xaml.media/loadedimagesurface_startloadfromuri_2119955733.md
@@ -32,8 +32,9 @@ An instance of [LoadedImageSurface](loadedimagesurface.md) with the image loaded
 
 ## -remarks
 
-By default, [LoadedImageSurface](loadedimagesurface.md) will fill up as much of the **desiredMaxSize** as possible while preserving the aspect ratio and image content
-of the incoming source. This may result in a decodedsize that differs from the input **desiredMaxSize**
+By default, [LoadedImageSurface](loadedimagesurface.md) will fill up as much of the **desiredMaxSize** as possible while preserving the aspect ratio and image content of the incoming source. This may result in a decoded size that differs from the input **desiredMaxSize**.
+
+The **desiredMaxSize** parameter also determines the surface allocation strategy. If either dimension of **desiredMaxSize** is 2340 pixels or less, the system allocates a non-virtual (performance-optimized) surface where the effective decode resolution is capped at `desiredMaxSize × currentDPIScale` (up to approximately 16,380 pixels). If either dimension exceeds 2340 pixels, a virtual surface is allocated that supports the full hardware texture limit (typically 16,384 pixels per dimension). For more information, see [LoadedImageSurface remarks](loadedimagesurface.md#surface-allocation-and-the-desiredmaxsize-threshold).
 
 ## -see-also
 


### PR DESCRIPTION
## Summary

Documents the undocumented 2340px per-dimension threshold in `LoadedImageSurface` that determines whether the system allocates a virtual or non-virtual surface.

**Related bug:** ADO#60474978

## Problem

When developers pass a `desiredMaxSize` between 2340 and 16,384 pixels, the image may be silently downscaled. This behavior is caused by an internal optimization heuristic (`c_maxPlateauScale = 7`, threshold = 16384 / 7 ≈ 2340px) that is not documented in the public API docs.

## Changes

- **`loadedimagesurface.md`** — Added a "Surface allocation and the desiredMaxSize threshold" subsection in Remarks explaining the two allocation paths and the 2340px boundary.
- **`loadedimagesurface_startloadfromuri_2119955733.md`** — Updated remarks to explain how `desiredMaxSize` affects surface allocation, with a link to the class-level docs.
- **`loadedimagesurface_startloadfromstream_1850726798.md`** — Same update as above.