### PR TITLE
Fix CreateToastNotifier docs: correct return type and add exception info

### DIFF
--- a/windows.ui.notifications/toastnotificationmanager_createtoastnotifier_1346219381.md
+++ b/windows.ui.notifications/toastnotificationmanager_createtoastnotifier_1346219381.md
@@ -11,12 +11,14 @@ public Windows.UI.Notifications.ToastNotifier CreateToastNotifier()
 # Windows.UI.Notifications.ToastNotificationManager.CreateToastNotifier
 
 ## -description
-Creates and initializes a new instance of the [ToastNotification](toastnotification.md), bound to the calling application, that lets you raise a toast notification to that app.
+Creates and initializes a new instance of the [ToastNotifier](toastnotifier.md), bound to the calling application, that lets you raise a toast notification to that app.
 
 ## -returns
 The object you will use to send the toast notification to the app.
 
 ## -remarks
+This method throws an exception if the app's manifest does not declare toast-capable, or if the caller doesn't have a valid AppUserModelID.
+
 Do not use this overload when creating a toast notifier for a desktop app. Use [CreateToastNotifier(appID)](toastnotificationmanager_createtoastnotifier_163337301.md) to supply the required [AppUserModelID](/windows/desktop/shell/appids).
 
 If your app uses a background voice-over-Internet protocol (VOIP) agent, it must specify the app ID to show a toast. Use the [CreateToastNotifier(appID)](toastnotificationmanager_createtoastnotifier_163337301.md) method overload.

--- a/windows.ui.notifications/toastnotificationmanager_createtoastnotifier_163337301.md
+++ b/windows.ui.notifications/toastnotificationmanager_createtoastnotifier_163337301.md
@@ -11,7 +11,7 @@ public Windows.UI.Notifications.ToastNotifier CreateToastNotifier(System.String 
 # Windows.UI.Notifications.ToastNotificationManager.CreateToastNotifier
 
 ## -description
-Creates and initializes a new instance of the [ToastNotification](toastnotification.md), bound to a specified app, usually another app in the same package.
+Creates and initializes a new instance of the [ToastNotifier](toastnotifier.md), bound to a specified app, usually another app in the same package.
 
 ## -parameters
 ### -param applicationId


### PR DESCRIPTION
## Summary

Fixes #1697 — The `CreateToastNotifier()` documentation incorrectly stated it returns a `ToastNotification` when it actually returns a `ToastNotifier`.

## Changes

- **Both overloads** (`CreateToastNotifier()` and `CreateToastNotifier(String)`): Changed the description from "Creates and initializes a new instance of the ToastNotification" → "ToastNotifier" with the correct link target.
- **Parameterless overload**: Added a remark noting the method can throw an exception if the app manifest doesn't declare toast-capable or lacks a valid AppUserModelID.