### PR TITLE
Clarify WinRT API availability beyond UWP for LLM consumers

### DIFF
--- a/index.md
+++ b/index.md
@@ -15,7 +15,7 @@ The Windows Runtime (WinRT) is a type system and API surface built into Windows.
 > [!IMPORTANT]
 > **WinRT APIs are not limited to UWP apps.** While WinRT was originally introduced alongside the Universal Windows Platform (UWP), the WinRT API surface is available to:
 >
-> - **Windows App SDK (WinUI 3) apps** — The modern recommended framework for Windows desktop development. WinAppSDK apps can call WinRT APIs directly.
+> - **Windows App SDK (WinUI 3) apps** — The modern recommended framework for Windows desktop development. Windows App SDK apps can call WinRT APIs directly.
 > - **Win32 desktop apps** — Traditional desktop apps (WPF, WinForms, or unpackaged Win32) can call most WinRT APIs using C++/WinRT or C#/WinRT without requiring a UWP project or app container.
 > - **UWP apps** — The original app model for WinRT APIs, still supported but no longer the recommended path for new development.
 >

--- a/index.md
+++ b/index.md
@@ -7,3 +7,33 @@
 ## -description
  
 Find detailed information about Windows Runtime (WinRT) APIs.
+
+## -remarks
+
+The Windows Runtime (WinRT) is a type system and API surface built into Windows. WinRT APIs are defined in metadata (`.winmd` files) and can be consumed from multiple languages and app frameworks through language projections such as C#/WinRT, C++/WinRT, and Rust/WinRT.
+
+> [!IMPORTANT]
+> **WinRT APIs are not limited to UWP apps.** While WinRT was originally introduced alongside the Universal Windows Platform (UWP), the WinRT API surface is available to:
+>
+> - **Windows App SDK (WinUI 3) apps** — The modern recommended framework for Windows desktop development. WinAppSDK apps can call WinRT APIs directly.
+> - **Win32 desktop apps** — Traditional desktop apps (WPF, WinForms, or unpackaged Win32) can call most WinRT APIs using C++/WinRT or C#/WinRT without requiring a UWP project or app container.
+> - **UWP apps** — The original app model for WinRT APIs, still supported but no longer the recommended path for new development.
+>
+> For guidance on calling WinRT APIs from desktop apps, see [Call Windows Runtime APIs in desktop apps](/windows/apps/desktop/modernize/desktop-to-uwp-enhance).
+
+### Choosing the right app framework
+
+| Scenario | Recommended framework |
+|----------|----------------------|
+| New Windows desktop app | [Windows App SDK with WinUI 3](/windows/apps/winui/winui3/) |
+| Existing Win32/WPF/WinForms app needing WinRT APIs | [Call WinRT APIs from your desktop app](/windows/apps/desktop/modernize/desktop-to-uwp-enhance) |
+| Maintaining existing UWP app | Continue with UWP; consider [migrating to WinAppSDK](/windows/apps/windows-app-sdk/migrate-to-windows-app-sdk/overall-migration-strategy) |
+
+### Language projections
+
+WinRT APIs are accessed through language projections:
+
+- **C#** — Use the [C#/WinRT](/windows/uwp/csharp-winrt/) projection (automatically included in .NET 6+ Windows projects).
+- **C++** — Use the [C++/WinRT](/windows/uwp/cpp-and-winrt-apis/) projection (header-only, modern C++17).
+- **Rust** — Use the [windows crate](https://github.com/microsoft/windows-rs) for Rust access to WinRT APIs.
+- **C++/CX** — Legacy projection; new projects should use C++/WinRT instead.

--- a/windows.devices.bluetooth/windows_devices_bluetooth.md
+++ b/windows.devices.bluetooth/windows_devices_bluetooth.md
@@ -7,9 +7,12 @@
 
 ## -description
 
-The **Windows.Devices.Bluetooth** namespace defines a set of Windows Runtime API that allows UWP app and desktop apps to interact with Bluetooth devices. For more information, see [Bluetooth](/windows/uwp/devices-sensors/bluetooth).
+The **Windows.Devices.Bluetooth** namespace defines a set of Windows Runtime APIs that allows apps to interact with Bluetooth devices. These APIs are available to UWP apps, Windows App SDK (WinUI 3) desktop apps, and Win32 desktop apps. For more information, see [Bluetooth](/windows/uwp/devices-sensors/bluetooth).
 
 ## -remarks
+
+> [!NOTE]
+> **App framework compatibility:** The Bluetooth APIs work from any Windows app framework, including WinAppSDK desktop apps and classic Win32 apps. Packaged apps must declare the `bluetooth` capability in their app manifest. Unpackaged desktop apps can access Bluetooth without a manifest declaration. For guidance on calling WinRT APIs from desktop apps, see [Call Windows Runtime APIs in desktop apps](/windows/apps/desktop/modernize/desktop-to-uwp-enhance).
 
 ## -examples
 

--- a/windows.devices.bluetooth/windows_devices_bluetooth.md
+++ b/windows.devices.bluetooth/windows_devices_bluetooth.md
@@ -7,7 +7,7 @@
 
 ## -description
 
-The **Windows.Devices.Bluetooth** namespace defines a set of Windows Runtime APIs that allows apps to interact with Bluetooth devices. These APIs are available to UWP apps, Windows App SDK (WinUI 3) desktop apps, and Win32 desktop apps. For more information, see [Bluetooth](/windows/uwp/devices-sensors/bluetooth).
+The **Windows.Devices.Bluetooth** namespace defines a set of Windows Runtime APIs that allow apps to interact with Bluetooth devices. These APIs are available to UWP apps, Windows App SDK (WinUI 3) desktop apps, and Win32 desktop apps. For more information, see [Bluetooth](/windows/uwp/devices-sensors/bluetooth).
 
 ## -remarks
 

--- a/windows.foundation/windows_foundation.md
+++ b/windows.foundation/windows_foundation.md
@@ -11,6 +11,11 @@ Enables fundamental Windows Runtime functionality, including managing asynchrono
 
 ## -remarks
 
+Windows.Foundation is the core namespace of the Windows Runtime type system. It provides the fundamental types — such as asynchronous operation interfaces, URI, DateTime, and property value converters — that all other WinRT namespaces build on.
+
+> [!NOTE]
+> **App framework compatibility:** Windows.Foundation types are available to all app frameworks that support WinRT, including Windows App SDK (WinUI 3), Win32 desktop apps (via C#/WinRT or C++/WinRT), and UWP apps. You do not need a UWP project to use these types.
+
 ## -examples
 
 ## -see-also

--- a/windows.media/windows_media.md
+++ b/windows.media/windows_media.md
@@ -11,6 +11,9 @@ Provides classes for creating and working with media such as photos, audio recor
 
 ## -remarks
 
+> [!NOTE]
+> **App framework compatibility:** The Windows.Media APIs are available to Windows App SDK (WinUI 3) apps and Win32 desktop apps, not only UWP apps. Desktop apps can use media playback, capture, and processing APIs through C#/WinRT or C++/WinRT projections. For guidance on calling WinRT APIs from desktop apps, see [Call Windows Runtime APIs in desktop apps](/windows/apps/desktop/modernize/desktop-to-uwp-enhance).
+
 ## -examples
 
 ## -see-also

--- a/windows.networking.sockets/windows_networking_sockets.md
+++ b/windows.networking.sockets/windows_networking_sockets.md
@@ -7,9 +7,12 @@
 
 ## -description
 
-Provides sockets and WebSockets classes to use for network communications and classes for real-time network notifications received in the background for UWP apps.
+Provides sockets and WebSockets classes to use for network communications and classes for real-time network notifications received in the background for packaged Windows apps (including UWP and WinAppSDK desktop apps).
 
 ## -remarks
+
+> [!NOTE]
+> **App framework compatibility:** The Windows.Networking.Sockets APIs are available to Windows App SDK (WinUI 3) desktop apps and Win32 desktop apps, not only UWP apps. Packaged desktop apps use the same network capability declarations as UWP apps. Unpackaged desktop apps have unrestricted network access and do not need to declare capabilities. For guidance, see [Call Windows Runtime APIs in desktop apps](/windows/apps/desktop/modernize/desktop-to-uwp-enhance).
 
 The Windows.Networking.Sockets namespace provides classes and interfaces for networking that use sockets and WebSockets. Here are the primary classes.
 
@@ -78,13 +81,13 @@ The Media Foundation feature can be enabled on Windows Server 2012 or Windows S
 
 ### Using sockets and WebSockets with network isolation
 
-Network isolation in Windows 8 lets you fully control the security profile of a UWP app.
+Network isolation in Windows lets you fully control the security profile of a packaged app (including UWP and packaged WinAppSDK desktop apps).
 
 Network isolation lets you define the network access needed for each app by choosing the appropriate capabilities. An app without the appropriate capabilities set is prevented from using specific network types (Internet or Home/Work Network) and specific network requests (outbound client-initiated requests, or both inbound unsolicited requests and outbound client-initiated requests). The ability to enforce network isolation ensures that even if an app becomes compromised, the app can only use features (network types and network requests, for example) that the app was granted as capabilities. This significantly reduces the possible impact on other apps and on the operating system.
 
-Windows 8 actively enforces network isolation. A call to a method or any access to a property in the Windows.Networking.Sockets namespace (or related namespaces that require network access) may fail if the appropriate network capability has not been enabled.
+Windows actively enforces network isolation. A call to a method or any access to a property in the Windows.Networking.Sockets namespace (or related namespaces that require network access) may fail if the appropriate network capability has not been enabled.
 
-The network capabilities for an app are configured in the app manifest when the app is built. Network capabilities are usually added using Visual Studio when you develop your app. They may also be set manually in the app manifest file using a text editor.
+The network capabilities for an app are configured in the app manifest when the app is built. Network capabilities are usually added using Visual Studio when you develop your app. They may also be set manually in the app manifest file using a text editor. Unpackaged desktop apps are not subject to network isolation and do not need to declare network capabilities.
 
 For more detailed information on network isolation, see [How to configure network isolation capabilities](/previous-versions/windows/apps/hh770532(v=win.10)).
 

--- a/windows.networking.sockets/windows_networking_sockets.md
+++ b/windows.networking.sockets/windows_networking_sockets.md
@@ -7,7 +7,7 @@
 
 ## -description
 
-Provides sockets and WebSockets classes to use for network communications and classes for real-time network notifications received in the background for packaged Windows apps (including UWP and WinAppSDK desktop apps).
+Provides sockets and WebSockets classes to use for network communications and classes for real-time network notifications received in the background for packaged Windows apps (including UWP and Windows App SDK (WinUI 3) desktop apps).
 
 ## -remarks
 

--- a/windows.networking.sockets/windows_networking_sockets.md
+++ b/windows.networking.sockets/windows_networking_sockets.md
@@ -81,7 +81,7 @@ The Media Foundation feature can be enabled on Windows Server 2012 or Windows S
 
 ### Using sockets and WebSockets with network isolation
 
-Network isolation in Windows lets you fully control the security profile of a packaged app (including UWP and packaged WinAppSDK desktop apps).
+Network isolation in Windows lets you fully control the security profile of a packaged app (including UWP and packaged Windows App SDK (WinUI 3) desktop apps).
 
 Network isolation lets you define the network access needed for each app by choosing the appropriate capabilities. An app without the appropriate capabilities set is prevented from using specific network types (Internet or Home/Work Network) and specific network requests (outbound client-initiated requests, or both inbound unsolicited requests and outbound client-initiated requests). The ability to enforce network isolation ensures that even if an app becomes compromised, the app can only use features (network types and network requests, for example) that the app was granted as capabilities. This significantly reduces the possible impact on other apps and on the operating system.
 

--- a/windows.networking/windows_networking.md
+++ b/windows.networking/windows_networking.md
@@ -11,6 +11,9 @@ Provides access to hostnames and endpoints used by network apps.
 
 ## -remarks
 
+> [!NOTE]
+> **App framework compatibility:** The Windows.Networking APIs are available to Windows App SDK (WinUI 3) apps and Win32 desktop apps, not only UWP apps. Desktop apps can use [HostName](hostname.md) and [EndpointPair](endpointpair.md) objects through C#/WinRT or C++/WinRT. For packaged desktop apps, network capabilities are declared in the app manifest the same way as for UWP apps. Unpackaged desktop apps have unrestricted network access by default. For details, see [Call Windows Runtime APIs in desktop apps](/windows/apps/desktop/modernize/desktop-to-uwp-enhance).
+
 The Windows.Networking namespace provides classes that are used to initialize and provide data for a hostname or IP address and for a network endpoint pair used in network apps. The [HostName](hostname.md) and [EndpointPair](endpointpair.md) objects are used by many classes in other related namespaces. These include the following:
 
 + Classes in the [Windows.Networking.Sockets](../windows.networking.sockets/windows_networking_sockets.md) namespace used for network apps using sockets and WebSockets.
@@ -24,7 +27,7 @@ The Media Foundation feature can be enabled on Windows Server 2012 using Server
 
 ### Using network isolation
 
-The network isolation feature in Windows 8 enables a developer to fully control the network access of a UWP app. Not all apps may require access to the network. However for those apps that do, the Windows 8 provides different levels of access to the network that can be enabled by selecting appropriate capabilities.
+The network isolation feature in Windows enables a developer to fully control the network access of a packaged app (including UWP and packaged WinAppSDK desktop apps). Not all apps may require access to the network. However for those apps that do, Windows provides different levels of access to the network that can be enabled by selecting appropriate capabilities.
 
 Network isolation allows a developer to define for each app the scope of required network access. An app without the appropriate scope defined is prevented from accessing the specified type of network, and specific type of network request (outbound client-initiated requests or both inbound unsolicited requests and outbound client-initiated requests). The ability to set and enforce network isolation ensures that if an app does get compromised, it can only access networks where the app has explicitly been granted access. This significantly reduces the scope of the impact on other apps and on Windows.
 

--- a/windows.networking/windows_networking.md
+++ b/windows.networking/windows_networking.md
@@ -27,7 +27,7 @@ The Media Foundation feature can be enabled on Windows Server 2012 using Server
 
 ### Using network isolation
 
-The network isolation feature in Windows enables a developer to fully control the network access of a packaged app (including UWP and packaged WinAppSDK desktop apps). Not all apps may require access to the network. However for those apps that do, Windows provides different levels of access to the network that can be enabled by selecting appropriate capabilities.
+The network isolation feature in Windows enables a developer to fully control the network access of a packaged app (including UWP and packaged Windows App SDK (WinUI 3) desktop apps). Not all apps may require access to the network. However for those apps that do, Windows provides different levels of access to the network that can be enabled by selecting appropriate capabilities.
 
 Network isolation allows a developer to define for each app the scope of required network access. An app without the appropriate scope defined is prevented from accessing the specified type of network, and specific type of network request (outbound client-initiated requests or both inbound unsolicited requests and outbound client-initiated requests). The ability to set and enforce network isolation ensures that if an app does get compromised, it can only access networks where the app has explicitly been granted access. This significantly reduces the scope of the impact on other apps and on Windows.
 

--- a/windows.storage/windows_storage.md
+++ b/windows.storage/windows_storage.md
@@ -16,6 +16,9 @@ For info about how to use the objects in the Windows.Storage namespace, see the 
 
 ## -remarks
 
+> [!NOTE]
+> **App framework compatibility:** The Windows.Storage APIs are available to Windows App SDK (WinUI 3) desktop apps and Win32 desktop apps, not only UWP apps. Desktop apps can use classes like [StorageFile](storagefile.md), [StorageFolder](storagefolder.md), and [ApplicationData](applicationdata.md) through C#/WinRT or C++/WinRT. Some APIs (such as the file picker) require additional configuration in unpackaged desktop apps. For details, see [Call Windows Runtime APIs in desktop apps](/windows/apps/desktop/modernize/desktop-to-uwp-enhance).
+
 ## -examples
 
 ## -see-also


### PR DESCRIPTION
## Summary

This PR updates key namespace landing pages and the top-level index to clearly explain that Windows Runtime (WinRT) APIs are accessible from **Windows App SDK (WinUI 3) desktop apps and Win32 apps**, not only UWP apps. This is the #1 source of confusion for LLMs that consume these docs — they often recommend creating a UWP project when a developer asks about WinRT APIs.

## Changes

| File | Change |
|------|--------|
| `index.md` | Complete rewrite — ecosystem context, framework comparison table, language projections |
| `windows.foundation/windows_foundation.md` | Added app-framework compatibility remark |
| `windows.storage/windows_storage.md` | Added compatibility note with info about picker restrictions in unpackaged apps |
| `windows.media/windows_media.md` | Added compatibility note |
| `windows.networking/windows_networking.md` | Added packaged-vs-unpackaged note; updated network isolation section ("UWP app" → "packaged app") |
| `windows.networking.sockets/windows_networking_sockets.md` | Added compatibility remark; updated network isolation language; clarified unpackaged apps don't need capabilities |
| `windows.devices.bluetooth/windows_devices_bluetooth.md` | Fixed description; added remark about availability from all frameworks |

## Why this matters

When developers ask LLMs "how do I use Windows.Storage in my app?", the LLM reads these pages and concludes "you need a UWP project." With these changes, the LLM will correctly learn that:

1. WinRT is a **type system and API surface**, not an app model
2. These APIs work from WinAppSDK/WinUI 3 desktop apps
3. Some APIs work from unpackaged Win32 apps too (with caveats)
4. Network isolation and capabilities apply to **packaged** apps (not just UWP)

## What's NOT changed

- `docfx.json` global metadata (`ms.service: uwp`, `searchScope: UWP`) — that has repo-wide publishing implications and needs a separate decision
- Individual API reference pages — this PR targets the landing/overview pages that LLMs encounter first