### PR TITLE
Add missing title attribute to index.md

### DIFF
--- a/index.md
+++ b/index.md
@@ -1,6 +1,7 @@
 ---
 -api-id: TP:winrt-api
 -api-name: Windows Runtime (WinRT) namespaces
+title: Windows Runtime (WinRT) API namespaces - Windows apps
 ---
 # Windows Runtime (WinRT) Namespaces
  


### PR DESCRIPTION
## Summary

Fixes the OPS build warning from `winapps-winrt-api-build`:

> "Warning occurred: Missing required attribute: 'title'. Add a title string to show in search engine results."

## Change

Added `title: Windows Runtime (WinRT) API namespaces - Windows apps` to the YAML front-matter of `index.md` at the repo root. The file had `-api-id` and `-api-name` but was missing the required `title` field that DocFX/OPS uses for SEO metadata.