### PR TITLE
Remove rolled-out IMPORTANT note from Windows.UI.Shell.Tasks API pages

### DIFF
--- a/windows.ui.shell.tasks/apptaskcontent.md
+++ b/windows.ui.shell.tasks/apptaskcontent.md
@@ -16,9 +16,6 @@ Represents the content displayed for an app task in the Windows Shell UI. Use th
 
 ## -remarks
 
-> [!IMPORTANT]
-> **App task support will start gradually rolling out to Windows 11 starting May, 2026.** The experiences enabled by `Windows.UI.Shell.Tasks` APIs require that the corresponding app task feature be present in the version of Windows where the app runs. Otherwise, these APIs will not have any effect.
-
 `AppTaskContent` can be constructed for different supported representations:
 
 - **Sequence of steps**: Shows step-by-step progress of task execution. Use [CreateSequenceOfSteps](apptaskcontent_createsequenceofsteps_2102567378.md).

--- a/windows.ui.shell.tasks/apptaskcontent_addbutton_519639533.md
+++ b/windows.ui.shell.tasks/apptaskcontent_addbutton_519639533.md
@@ -26,9 +26,6 @@ The URI that is launched when the user clicks the button.
 
 ## -remarks
 
-> [!IMPORTANT]
-> **App task support will start gradually rolling out to Windows 11 starting May, 2026.** The experiences enabled by `Windows.UI.Shell.Tasks` APIs require that the corresponding app task feature be present in the version of Windows where the app runs. Otherwise, these APIs will not have any effect.
-
 Use buttons when the task needs user attention and you want to provide simple action choices. The maximum number of buttons you can add is defined by [MaxButtons](apptaskcontent_maxbuttons.md). Typically used in combination with [SetQuestion](apptaskcontent_setquestion_1132443299.md) when the task state is `NeedsAttention`.
 
 ## -see-also

--- a/windows.ui.shell.tasks/apptaskcontent_creategeneratedassetsresult_836752552.md
+++ b/windows.ui.shell.tasks/apptaskcontent_creategeneratedassetsresult_836752552.md
@@ -26,9 +26,6 @@ A new [AppTaskContent](apptaskcontent.md) object that displays the generated ass
 
 ## -remarks
 
-> [!IMPORTANT]
-> **App task support will start gradually rolling out to Windows 11 starting May, 2026.** The experiences enabled by `Windows.UI.Shell.Tasks` APIs require that the corresponding app task feature be present in the version of Windows where the app runs. Otherwise, these APIs will not have any effect.
-
 Use this content type when a task produces files or other content that you want to display to the user.
 
 ## -see-also

--- a/windows.ui.shell.tasks/apptaskcontent_createpreviewthumbnail_1460480113.md
+++ b/windows.ui.shell.tasks/apptaskcontent_createpreviewthumbnail_1460480113.md
@@ -30,9 +30,6 @@ A new [AppTaskContent](apptaskcontent.md) object that displays an image preview.
 
 ## -remarks
 
-> [!IMPORTANT]
-> **App task support will start gradually rolling out to Windows 11 starting May, 2026.** The experiences enabled by `Windows.UI.Shell.Tasks` APIs require that the corresponding app task feature be present in the version of Windows where the app runs. Otherwise, these APIs will not have any effect.
-
 ## -see-also
 
 ## -examples

--- a/windows.ui.shell.tasks/apptaskcontent_createsequenceofsteps_2102567378.md
+++ b/windows.ui.shell.tasks/apptaskcontent_createsequenceofsteps_2102567378.md
@@ -30,9 +30,6 @@ A new [AppTaskContent](apptaskcontent.md) object that displays step-by-step prog
 
 ## -remarks
 
-> [!IMPORTANT]
-> **App task support will start gradually rolling out to Windows 11 starting May, 2026.** The experiences enabled by `Windows.UI.Shell.Tasks` APIs require that the corresponding app task feature be present in the version of Windows where the app runs. Otherwise, these APIs will not have any effect.
-
 This content type is useful for tasks that process a series of steps, such as AI agent workflows. The task doesn't need to know what steps will come next; it shows only past and current progress.
 
 ## -see-also

--- a/windows.ui.shell.tasks/apptaskcontent_createtextsummaryresult_779573599.md
+++ b/windows.ui.shell.tasks/apptaskcontent_createtextsummaryresult_779573599.md
@@ -26,9 +26,6 @@ A new [AppTaskContent](apptaskcontent.md) object that displays a text summary.
 
 ## -remarks
 
-> [!IMPORTANT]
-> **App task support will start gradually rolling out to Windows 11 starting May, 2026.** The experiences enabled by `Windows.UI.Shell.Tasks` APIs require that the corresponding app task feature be present in the version of Windows where the app runs. Otherwise, these APIs will not have any effect.
-
 Use this content type when a task completes and you want to provide a brief text description of the result.
 
 ## -see-also

--- a/windows.ui.shell.tasks/apptaskcontent_maxbuttons.md
+++ b/windows.ui.shell.tasks/apptaskcontent_maxbuttons.md
@@ -20,9 +20,6 @@ The maximum number of buttons that can be added using [AddButton](apptaskcontent
 
 ## -remarks
 
-> [!IMPORTANT]
-> **App task support will start gradually rolling out to Windows 11 starting May, 2026.** The experiences enabled by `Windows.UI.Shell.Tasks` APIs require that the corresponding app task feature be present in the version of Windows where the app runs. Otherwise, these APIs will not have any effect.
-
 ## -see-also
 
 ## -examples

--- a/windows.ui.shell.tasks/apptaskcontent_setquestion_1132443299.md
+++ b/windows.ui.shell.tasks/apptaskcontent_setquestion_1132443299.md
@@ -22,9 +22,6 @@ The question text to display to the user.
 
 ## -remarks
 
-> [!IMPORTANT]
-> **App task support will start gradually rolling out to Windows 11 starting May, 2026.** The experiences enabled by `Windows.UI.Shell.Tasks` APIs require that the corresponding app task feature be present in the version of Windows where the app runs. Otherwise, these APIs will not have any effect.
-
 Use this method in combination with [AddButton](apptaskcontent_addbutton_519639533.md) or [SetTextInput](apptaskcontent_settextinput_1945138728.md) to prompt the user for input when the task requires a decision.
 
 ## -see-also

--- a/windows.ui.shell.tasks/apptaskcontent_settextinput_1945138728.md
+++ b/windows.ui.shell.tasks/apptaskcontent_settextinput_1945138728.md
@@ -26,9 +26,6 @@ A URI template string containing `{userTextInput}` that will be replaced with th
 
 ## -remarks
 
-> [!IMPORTANT]
-> **App task support will start gradually rolling out to Windows 11 starting May, 2026.** The experiences enabled by `Windows.UI.Shell.Tasks` APIs require that the corresponding app task feature be present in the version of Windows where the app runs. Otherwise, these APIs will not have any effect.
-
 Use this method to collect text input from the user when the task needs attention. The `{userTextInput}` expression in the URI template is replaced with the URL-encoded user input. For example, if the template is `my-app:task/?response={userTextInput}` and the user enters "scope only", the resulting URI will be `my-app:task/?response=scope%20only`.
 
 ## -see-also

--- a/windows.ui.shell.tasks/apptaskinfo.md
+++ b/windows.ui.shell.tasks/apptaskinfo.md
@@ -16,9 +16,6 @@ Represents an app task that can be displayed in the Windows Shell.
 
 ## -remarks
 
-> [!IMPORTANT]
-> **App task support will start gradually rolling out to Windows 11 starting May, 2026.** The experiences enabled by `Windows.UI.Shell.Tasks` APIs require that the corresponding app task feature be present in the version of Windows where the app runs. Otherwise, these APIs will not have any effect.
-
 This class supports creating, updating, and removing task representations. Tasks are persisted across app sessions and system reboots.
 
 For each task, create a new `AppTaskInfo` instance and modify it to represent the task state. When a task is no longer relevant, call [Remove](apptaskinfo_remove_13687727.md) to remove it from the Shell.

--- a/windows.ui.shell.tasks/apptaskinfo_create_1666284704.md
+++ b/windows.ui.shell.tasks/apptaskinfo_create_1666284704.md
@@ -41,9 +41,6 @@ A new [AppTaskInfo](apptaskinfo.md) object that represents the task.
 
 ## -remarks
 
-> [!IMPORTANT]
-> **App task support will start gradually rolling out to Windows 11 starting May, 2026.** The experiences enabled by `Windows.UI.Shell.Tasks` APIs require that the corresponding app task feature be present in the version of Windows where the app runs. Otherwise, these APIs will not have any effect.
-
 The title is required; this method throws an exception if the title is not provided.
 
 ## -see-also

--- a/windows.ui.shell.tasks/apptaskinfo_deeplink.md
+++ b/windows.ui.shell.tasks/apptaskinfo_deeplink.md
@@ -20,9 +20,6 @@ A URI that is launched when the user clicks on the task representation in the Sh
 
 ## -remarks
 
-> [!IMPORTANT]
-> **App task support will start gradually rolling out to Windows 11 starting May, 2026.** The experiences enabled by `Windows.UI.Shell.Tasks` APIs require that the corresponding app task feature be present in the version of Windows where the app runs. Otherwise, these APIs will not have any effect.
-
 The deep link URI allows navigation to the full task view in the app.
 
 ## -see-also

--- a/windows.ui.shell.tasks/apptaskinfo_endtime.md
+++ b/windows.ui.shell.tasks/apptaskinfo_endtime.md
@@ -20,9 +20,6 @@ The time when the task reached an ending state (such as `Completed` or `Error`),
 
 ## -remarks
 
-> [!IMPORTANT]
-> **App task support will start gradually rolling out to Windows 11 starting May, 2026.** The experiences enabled by `Windows.UI.Shell.Tasks` APIs require that the corresponding app task feature be present in the version of Windows where the app runs. Otherwise, these APIs will not have any effect.
-
 ## -see-also
 
 ## -examples

--- a/windows.ui.shell.tasks/apptaskinfo_findall_1149612203.md
+++ b/windows.ui.shell.tasks/apptaskinfo_findall_1149612203.md
@@ -20,9 +20,6 @@ An array of [AppTaskInfo](apptaskinfo.md) objects that represent all tasks creat
 
 ## -remarks
 
-> [!IMPORTANT]
-> **App task support will start gradually rolling out to Windows 11 starting May, 2026.** The experiences enabled by `Windows.UI.Shell.Tasks` APIs require that the corresponding app task feature be present in the version of Windows where the app runs. Otherwise, these APIs will not have any effect.
-
 Use this method at app startup to enumerate existing tasks that may have been created previously. Tasks are persisted beyond the lifetime of the calling app and also persist through reboots. The returned collection includes tasks that have been hidden by the user. If [IsSupported](apptaskinfo_issupported_930300905.md) returns `false`, this method returns an empty collection.
 
 ## -see-also

--- a/windows.ui.shell.tasks/apptaskinfo_getcompletedsteps_215791606.md
+++ b/windows.ui.shell.tasks/apptaskinfo_getcompletedsteps_215791606.md
@@ -20,9 +20,6 @@ An array of strings that represent the completed steps in order.
 
 ## -remarks
 
-> [!IMPORTANT]
-> **App task support will start gradually rolling out to Windows 11 starting May, 2026.** The experiences enabled by `Windows.UI.Shell.Tasks` APIs require that the corresponding app task feature be present in the version of Windows where the app runs. Otherwise, these APIs will not have any effect.
-
 This method is useful when updating a task that was created with [AppTaskContent.CreateSequenceOfSteps](apptaskcontent_createsequenceofsteps_2102567378.md). Use the returned steps along with [GetExecutingStep](apptaskinfo_getexecutingstep_99219571.md) to create updated content.
 
 ## -see-also

--- a/windows.ui.shell.tasks/apptaskinfo_getexecutingstep_99219571.md
+++ b/windows.ui.shell.tasks/apptaskinfo_getexecutingstep_99219571.md
@@ -20,9 +20,6 @@ The currently executing step.
 
 ## -remarks
 
-> [!IMPORTANT]
-> **App task support will start gradually rolling out to Windows 11 starting May, 2026.** The experiences enabled by `Windows.UI.Shell.Tasks` APIs require that the corresponding app task feature be present in the version of Windows where the app runs. Otherwise, these APIs will not have any effect.
-
 This method is useful when updating a task that was created with [AppTaskContent.CreateSequenceOfSteps](apptaskcontent_createsequenceofsteps_2102567378.md). Use the returned step along with [GetCompletedSteps](apptaskinfo_getcompletedsteps_215791606.md) to create updated content.
 
 ## -see-also

--- a/windows.ui.shell.tasks/apptaskinfo_hiddenbyuser.md
+++ b/windows.ui.shell.tasks/apptaskinfo_hiddenbyuser.md
@@ -20,9 +20,6 @@ Gets a value that indicates whether the user has hidden this task through the Wi
 
 ## -remarks
 
-> [!IMPORTANT]
-> **App task support will start gradually rolling out to Windows 11 starting May, 2026.** The experiences enabled by `Windows.UI.Shell.Tasks` APIs require that the corresponding app task feature be present in the version of Windows where the app runs. Otherwise, these APIs will not have any effect.
-
 When a user hides a task from the taskbar it has no impact on the task running in the app; its representation is simply removed from the taskbar. Hidden tasks are still returned by [FindAll](apptaskinfo_findall_1149612203.md).
 
 ## -see-also

--- a/windows.ui.shell.tasks/apptaskinfo_iconuri.md
+++ b/windows.ui.shell.tasks/apptaskinfo_iconuri.md
@@ -20,9 +20,6 @@ The path to an icon that represents the task.
 
 ## -remarks
 
-> [!IMPORTANT]
-> **App task support will start gradually rolling out to Windows 11 starting May, 2026.** The experiences enabled by `Windows.UI.Shell.Tasks` APIs require that the corresponding app task feature be present in the version of Windows where the app runs. Otherwise, these APIs will not have any effect.
-
 These path formats are supported:
 
 - `ms-appx:///` - Package-relative URI to the app's package folder (recommended)

--- a/windows.ui.shell.tasks/apptaskinfo_id.md
+++ b/windows.ui.shell.tasks/apptaskinfo_id.md
@@ -20,9 +20,6 @@ The unique identifier for this task.
 
 ## -remarks
 
-> [!IMPORTANT]
-> **App task support will start gradually rolling out to Windows 11 starting May, 2026.** The experiences enabled by `Windows.UI.Shell.Tasks` APIs require that the corresponding app task feature be present in the version of Windows where the app runs. Otherwise, these APIs will not have any effect.
-
 ## -see-also
 
 ## -examples

--- a/windows.ui.shell.tasks/apptaskinfo_issupported_930300905.md
+++ b/windows.ui.shell.tasks/apptaskinfo_issupported_930300905.md
@@ -20,9 +20,6 @@ Gets a value that indicates whether the app task feature is supported on the cur
 
 ## -remarks
 
-> [!IMPORTANT]
-> **App task support will start gradually rolling out to Windows 11 starting May, 2026.** The experiences enabled by `Windows.UI.Shell.Tasks` APIs require that the corresponding app task feature be present in the version of Windows where the app runs. Otherwise, these APIs will not have any effect.
-
 Call this method before using other `AppTaskInfo` APIs. At startup, call `IsSupported` and [FindAll](apptaskinfo_findall_1149612203.md) to enumerate existing tasks that may have been added previously. `AppTaskInfo` instances are persisted beyond the lifetime of the calling app and also persist through reboots. If an app adds a task, it is the app's responsibility to remove it at the appropriate time in the future. If this method returns `false`, [FindAll](apptaskinfo_findall_1149612203.md) returns an empty collection.
 
 ## -see-also

--- a/windows.ui.shell.tasks/apptaskinfo_remove_13687727.md
+++ b/windows.ui.shell.tasks/apptaskinfo_remove_13687727.md
@@ -16,9 +16,6 @@ Removes this task from the Windows Shell, but doesn't change its state.
 
 ## -remarks
 
-> [!IMPORTANT]
-> **App task support will start gradually rolling out to Windows 11 starting May, 2026.** The experiences enabled by `Windows.UI.Shell.Tasks` APIs require that the corresponding app task feature be present in the version of Windows where the app runs. Otherwise, these APIs will not have any effect.
-
 Call this method when the app determines it no longer wants to display the task on the taskbar, such as when the task has completed or the user has deleted the task from within the app. Calling `Remove` multiple times is harmless.
 
 ## -see-also

--- a/windows.ui.shell.tasks/apptaskinfo_starttime.md
+++ b/windows.ui.shell.tasks/apptaskinfo_starttime.md
@@ -20,9 +20,6 @@ The time when this task was created.
 
 ## -remarks
 
-> [!IMPORTANT]
-> **App task support will start gradually rolling out to Windows 11 starting May, 2026.** The experiences enabled by `Windows.UI.Shell.Tasks` APIs require that the corresponding app task feature be present in the version of Windows where the app runs. Otherwise, these APIs will not have any effect.
-
 ## -see-also
 
 ## -examples

--- a/windows.ui.shell.tasks/apptaskinfo_state.md
+++ b/windows.ui.shell.tasks/apptaskinfo_state.md
@@ -20,9 +20,6 @@ A value of the enumeration that indicates the current state of the task.
 
 ## -remarks
 
-> [!IMPORTANT]
-> **App task support will start gradually rolling out to Windows 11 starting May, 2026.** The experiences enabled by `Windows.UI.Shell.Tasks` APIs require that the corresponding app task feature be present in the version of Windows where the app runs. Otherwise, these APIs will not have any effect.
-
 Use the [Update](apptaskinfo_update_1997319879.md) or [UpdateState](apptaskinfo_updatestate_321093297.md) methods to set state values.
 
 ## -see-also

--- a/windows.ui.shell.tasks/apptaskinfo_subtitle.md
+++ b/windows.ui.shell.tasks/apptaskinfo_subtitle.md
@@ -20,9 +20,6 @@ The subtitle that provides additional context for the task.
 
 ## -remarks
 
-> [!IMPORTANT]
-> **App task support will start gradually rolling out to Windows 11 starting May, 2026.** The experiences enabled by `Windows.UI.Shell.Tasks` APIs require that the corresponding app task feature be present in the version of Windows where the app runs. Otherwise, these APIs will not have any effect.
-
 The subtitle is optional and provides additional information about the task.
 
 Use the [Create](apptaskinfo_create_1666284704.md) or [UpdateTitles](apptaskinfo_updatetitles_872526535.md) methods to set title and subtitle values.

--- a/windows.ui.shell.tasks/apptaskinfo_title.md
+++ b/windows.ui.shell.tasks/apptaskinfo_title.md
@@ -20,9 +20,6 @@ The title that represents the type of task.
 
 ## -remarks
 
-> [!IMPORTANT]
-> **App task support will start gradually rolling out to Windows 11 starting May, 2026.** The experiences enabled by `Windows.UI.Shell.Tasks` APIs require that the corresponding app task feature be present in the version of Windows where the app runs. Otherwise, these APIs will not have any effect.
-
 Title and subtitle are text fields that represent the type of task. They are displayed in the UI, sometimes appended together (for example, "Researcher - Trends in smart appliances"). Tasks are grouped based on the title.
 
 Use the [Create](apptaskinfo_create_1666284704.md) or [UpdateTitles](apptaskinfo_updatetitles_872526535.md) methods to set title and subtitle values.

--- a/windows.ui.shell.tasks/apptaskinfo_update_1997319879.md
+++ b/windows.ui.shell.tasks/apptaskinfo_update_1997319879.md
@@ -26,9 +26,6 @@ The new content to display for this task, created using one of the [AppTaskConte
 
 ## -remarks
 
-> [!IMPORTANT]
-> **App task support will start gradually rolling out to Windows 11 starting May, 2026.** The experiences enabled by `Windows.UI.Shell.Tasks` APIs require that the corresponding app task feature be present in the version of Windows where the app runs. Otherwise, these APIs will not have any effect.
-
 Use this method to update the task representation as the task progresses, encounters errors, or completes.
 
 ## -see-also

--- a/windows.ui.shell.tasks/apptaskinfo_updatedeeplink_1523659627.md
+++ b/windows.ui.shell.tasks/apptaskinfo_updatedeeplink_1523659627.md
@@ -22,9 +22,6 @@ The new URI that will be launched when the user clicks on the task representatio
 
 ## -remarks
 
-> [!IMPORTANT]
-> **App task support will start gradually rolling out to Windows 11 starting May, 2026.** The experiences enabled by `Windows.UI.Shell.Tasks` APIs require that the corresponding app task feature be present in the version of Windows where the app runs. Otherwise, these APIs will not have any effect.
-
 ## -see-also
 
 ## -examples

--- a/windows.ui.shell.tasks/apptaskinfo_updatestate_321093297.md
+++ b/windows.ui.shell.tasks/apptaskinfo_updatestate_321093297.md
@@ -22,9 +22,6 @@ A value of the enumeration that indicates the new state of the task.
 
 ## -remarks
 
-> [!IMPORTANT]
-> **App task support will start gradually rolling out to Windows 11 starting May, 2026.** The experiences enabled by `Windows.UI.Shell.Tasks` APIs require that the corresponding app task feature be present in the version of Windows where the app runs. Otherwise, these APIs will not have any effect.
-
 ## -see-also
 
 ## -examples

--- a/windows.ui.shell.tasks/apptaskinfo_updatetitles_872526535.md
+++ b/windows.ui.shell.tasks/apptaskinfo_updatetitles_872526535.md
@@ -26,9 +26,6 @@ The new subtitle for the task. Can be an empty string.
 
 ## -remarks
 
-> [!IMPORTANT]
-> **App task support will start gradually rolling out to Windows 11 starting May, 2026.** The experiences enabled by `Windows.UI.Shell.Tasks` APIs require that the corresponding app task feature be present in the version of Windows where the app runs. Otherwise, these APIs will not have any effect.
-
 Use this method to update the task titles, for example, when an agent takes time to generate an appropriate name for a conversation.
 
 ## -see-also

--- a/windows.ui.shell.tasks/apptaskresultasset.md
+++ b/windows.ui.shell.tasks/apptaskresultasset.md
@@ -16,9 +16,6 @@ Represents an asset produced by a completed task, such as a file or other genera
 
 ## -remarks
 
-> [!IMPORTANT]
-> **App task support will start gradually rolling out to Windows 11 starting May, 2026.** The experiences enabled by `Windows.UI.Shell.Tasks` APIs require that the corresponding app task feature be present in the version of Windows where the app runs. Otherwise, these APIs will not have any effect.
-
 Use this class with [AppTaskContent.CreateGeneratedAssetsResult](apptaskcontent_creategeneratedassetsresult_836752552.md) to display task results that include generated assets.
 
 ## -see-also

--- a/windows.ui.shell.tasks/apptaskresultasset_apptaskresultasset_1675121420.md
+++ b/windows.ui.shell.tasks/apptaskresultasset_apptaskresultasset_1675121420.md
@@ -34,9 +34,6 @@ The URI of the generated asset (for example, a file path).
 
 ## -remarks
 
-> [!IMPORTANT]
-> **App task support will start gradually rolling out to Windows 11 starting May, 2026.** The experiences enabled by `Windows.UI.Shell.Tasks` APIs require that the corresponding app task feature be present in the version of Windows where the app runs. Otherwise, these APIs will not have any effect.
-
 ## -see-also
 
 ## -examples

--- a/windows.ui.shell.tasks/apptaskstate.md
+++ b/windows.ui.shell.tasks/apptaskstate.md
@@ -38,9 +38,6 @@ The task completed with an error state.
 
 ## -remarks
 
-> [!IMPORTANT]
-> **App task support will start gradually rolling out to Windows 11 starting May, 2026.** The experiences enabled by `Windows.UI.Shell.Tasks` APIs require that the corresponding app task feature be present in the version of Windows where the app runs. Otherwise, these APIs will not have any effect.
-
 ## -see-also
 
 ## -examples

--- a/windows.ui.shell.tasks/windows_ui_shell_tasks.md
+++ b/windows.ui.shell.tasks/windows_ui_shell_tasks.md
@@ -13,9 +13,6 @@ Provides APIs that allow apps to represent long-running tasks in the Windows She
 
 ## -remarks
 
-> [!IMPORTANT]
-> **App task support will start gradually rolling out to Windows 11 starting May, 2026.** The experiences enabled by `Windows.UI.Shell.Tasks` APIs require that the corresponding app task feature be present in the version of Windows where the app runs. Otherwise, these APIs will not have any effect.
-
 ### Using shell tasks APIs
 
 Apps that use these APIs need to be packaged. See [Packaging overview](/windows/apps/package-and-deploy/packaging/) for more info.


### PR DESCRIPTION
The app task feature has now shipped; the rollout notice ("App task support will start gradually rolling out to Windows 11 starting May, 2026.") is no longer needed. Removed from all 33 files in the windows.ui.shell.tasks/ namespace.