### PR TITLE
Fix NavigationView IsBackButtonVisible property description

### DIFF
--- a/windows.ui.xaml.controls/navigationview_isbackbuttonvisible.md
+++ b/windows.ui.xaml.controls/navigationview_isbackbuttonvisible.md
@@ -11,7 +11,7 @@ public NavigationViewBackButtonVisible IsBackButtonVisible { get;  set; }
 
 ## -description
 
-Gets or sets a value that indicates whether the back button is enabled or disabled.
+Gets or sets a value that indicates whether the back button is visible or not.
 
 Equivalent **WinUI 2 API for UWP**: [Microsoft.UI.Xaml.Controls.NavigationView.IsBackButtonVisible](/windows/winui/api/microsoft.ui.xaml.controls.navigationview.isbackbuttonvisible) (for WinUI in the [Windows App SDK](/windows/apps/windows-app-sdk/), see the **[Windows App SDK namespaces](/windows/windows-app-sdk/api/winrt/)**).
 


### PR DESCRIPTION
Should I expand the description so it aligns with the equivalent [Microsoft.UI.Xaml.Controls.NavigationView.IsBackButtonVisible](https://github.com/MicrosoftDocs/winapps-winrt-api/blob/docs/microsoft.ui.xaml.controls/navigationview_isbackbuttonvisible.md) as well?