### PR TITLE
Document User age-verification and age-range methods

### DIFF
--- a/windows.system/user_getageverificationstatusasync.md
+++ b/windows.system/user_getageverificationstatusasync.md
@@ -1,0 +1,100 @@
+---
+-api-id: M:Windows.System.User.GetAgeVerificationStatusAsync
+-api-type: winrt method
+---
+
+<!-- Method syntax
+public Windows.Foundation.IAsyncOperation<Windows.System.UserAgeVerificationStatus> GetAgeVerificationStatusAsync()
+-->
+
+# Windows.System.User.GetAgeVerificationStatusAsync
+
+## -description
+Retrieves a value indicating whether and how the current user's age has been verified.
+
+## -returns
+An asynchronous operation that returns a [UserAgeVerificationStatus](https://learn.microsoft.com/uwp/api/windows.system.userageverificationstatus) value for the current user.
+
+## -remarks
+The following table describes the possible return values.
+
+| Value | Name | Meaning |
+| ---: | --- | --- |
+| 0 | `NotApplicable` | Age verification doesn't apply, no verification signal is available, or the feature is unavailable or disabled. |
+| 1 | `TemporarilyUnavailable` | The verification status can't currently be determined. The app can retry later. |
+| 2 | `Unverified` | The user's age hasn't been verified. |
+| 3 | `OptedOut` | The user has opted out of age verification. |
+| 4 | `Verified` | The user's age has been verified. |
+
+`NotApplicable` and `TemporarilyUnavailable` don't establish that the user is either verified or unverified. Handle them as separate states.
+
+- Call this method on the [User](https://learn.microsoft.com/uwp/api/windows.system.user) object for the user running the current process. Use [User.GetDefault](https://learn.microsoft.com/uwp/api/windows.system.user.getdefault) to obtain that user directly.
+- The app package must declare the `userAccountInformation` capability. A caller without access, or a caller using a `User` object for a different user, can receive `E_ACCESSDENIED`.
+- In C++/WinRT, call `.get()` from a suitable non-UI thread or use `co_await` from a coroutine.
+
+### Administrative policy
+
+Administrators can disable the Digital Safety age APIs or configure a default verification status through Group Policy or MDM. When the APIs are disabled, this method returns `NotApplicable`. When a default status is configured, this method returns the configured `Verified` or `Unverified` value.
+
+## -examples
+```cppwinrt
+#include <winrt/Windows.Foundation.h>
+#include <winrt/Windows.System.h>
+
+using namespace winrt;
+using namespace winrt::Windows::System;
+
+int wmain()
+{
+    init_apartment();
+
+    User user = User::GetDefault();
+    UserAgeVerificationStatus status =
+        user.GetAgeVerificationStatusAsync().get();
+
+    switch (status)
+    {
+    case UserAgeVerificationStatus::Verified:
+        // The user's age is verified.
+        break;
+    case UserAgeVerificationStatus::Unverified:
+        // The user's age isn't verified.
+        break;
+    case UserAgeVerificationStatus::OptedOut:
+        // The user opted out.
+        break;
+    case UserAgeVerificationStatus::TemporarilyUnavailable:
+        // Retry later or use the app's fallback experience.
+        break;
+    case UserAgeVerificationStatus::NotApplicable:
+        // Use the app's fallback experience.
+        break;
+    }
+}
+```
+
+```csharp
+User user = User.GetDefault();
+UserAgeVerificationStatus status =
+    await user.GetAgeVerificationStatusAsync();
+
+switch (status)
+{
+    case UserAgeVerificationStatus.Verified:
+        break;
+    case UserAgeVerificationStatus.Unverified:
+        break;
+    case UserAgeVerificationStatus.OptedOut:
+        break;
+    case UserAgeVerificationStatus.TemporarilyUnavailable:
+        break;
+    case UserAgeVerificationStatus.NotApplicable:
+        break;
+}
+```
+
+## -see-also
+[User](https://learn.microsoft.com/uwp/api/windows.system.user), [User.GetDefault](https://learn.microsoft.com/uwp/api/windows.system.user.getdefault), [User.FindAllAsync](https://learn.microsoft.com/uwp/api/windows.system.user.findallasync), [User.GetUserAgeRangeAsync](https://learn.microsoft.com/uwp/api/windows.system.user.getuseragerangeasync), [UserAgeVerificationStatus](https://learn.microsoft.com/uwp/api/windows.system.userageverificationstatus)
+
+## -capabilities
+userAccountInformation

--- a/windows.system/user_getuseragerangeasync.md
+++ b/windows.system/user_getuseragerangeasync.md
@@ -1,0 +1,90 @@
+---
+-api-id: M:Windows.System.User.GetUserAgeRangeAsync
+-api-type: winrt method
+---
+
+<!-- Method syntax
+public Windows.Foundation.IAsyncOperation<Windows.System.UserAgeRange> GetUserAgeRangeAsync()
+-->
+
+# Windows.System.User.GetUserAgeRangeAsync
+
+## -description
+Retrieves the age range that the current user falls into.
+
+## -returns
+An asynchronous operation that returns a [UserAgeRange](https://learn.microsoft.com/uwp/api/windows.system.useragerange) for the current user, or `null` when the age range is unknown or unavailable.
+
+## -remarks
+`UserAgeRange.Lower` and `UserAgeRange.Upper` are inclusive bounds.
+
+| Age group | `Lower` | `Upper` |
+| --- | ---: | ---: |
+| Under 10 | 0 | 9 |
+| 10-12 | 10 | 12 |
+| 13-15 | 13 | 15 |
+| 16-17 | 16 | 17 |
+| 18 or older | 18 | `INT32_MAX` |
+
+The operation returns `null` when the user's age isn't known, the feature is unavailable, or the APIs are disabled by administrative policy. A `null` result is an expected outcome and must not be treated as an exact age or as the 18-or-older range.
+
+- Call this method on the [User](https://learn.microsoft.com/uwp/api/windows.system.user) object for the user running the current process. Use [User.GetDefault](https://learn.microsoft.com/uwp/api/windows.system.user.getdefault) to obtain that user directly.
+- The app package must declare the `userAccountInformation` capability. A caller without access, or a caller using a `User` object for a different user, can receive `E_ACCESSDENIED`.
+- This method returns an age bucket, not the user's exact age or date of birth.
+- In C++/WinRT, call `.get()` from a suitable non-UI thread or use `co_await` from a coroutine.
+
+### Administrative policy
+
+Administrators can disable the Digital Safety age APIs or configure a default age group through Group Policy or MDM. When the APIs are disabled, this method returns `null`. When a default age group is configured, this method returns the `UserAgeRange` that corresponds to that group.
+
+## -examples
+```cppwinrt
+#include <winrt/Windows.Foundation.h>
+#include <winrt/Windows.System.h>
+
+using namespace winrt;
+using namespace winrt::Windows::System;
+
+int wmain()
+{
+    init_apartment();
+
+    User user = User::GetDefault();
+    UserAgeRange range = user.GetUserAgeRangeAsync().get();
+
+    if (range)
+    {
+        int32_t lower = range.Lower();
+        int32_t upper = range.Upper();
+
+        // Use the inclusive age bucket.
+    }
+    else
+    {
+        // Use the app's fallback experience.
+    }
+}
+```
+
+```csharp
+User user = User.GetDefault();
+UserAgeRange range = await user.GetUserAgeRangeAsync();
+
+if (range != null)
+{
+    int lower = range.Lower;
+    int upper = range.Upper;
+
+    // Use the inclusive age bucket.
+}
+else
+{
+    // Use the app's fallback experience.
+}
+```
+
+## -see-also
+[User](https://learn.microsoft.com/uwp/api/windows.system.user), [User.GetDefault](https://learn.microsoft.com/uwp/api/windows.system.user.getdefault), [User.FindAllAsync](https://learn.microsoft.com/uwp/api/windows.system.user.findallasync), [User.GetAgeVerificationStatusAsync](https://learn.microsoft.com/uwp/api/windows.system.user.getageverificationstatusasync), [UserAgeRange](https://learn.microsoft.com/uwp/api/windows.system.useragerange)
+
+## -capabilities
+userAccountInformation


### PR DESCRIPTION
## Summary

Two `Windows.System.User` methods shipped in the Windows SDK (Windows 11, requires the `userAccountInformation` capability), but their live reference pages were auto-generated stubs with no authored content:

- `User.GetAgeVerificationStatusAsync` — returns a `UserAgeVerificationStatus` for the current user.
- `User.GetUserAgeRangeAsync` — returns a `UserAgeRange` (inclusive age bucket) for the current user, or `null` when unknown/unavailable.

This PR adds winrt-api overlay files that merge authored content into those existing pages via the `-api-id` front-matter key. Each file provides:

- A method **description** and **return-value** details (including the full `UserAgeVerificationStatus` value table and the `UserAgeRange` age-bucket table).
- **Remarks** covering the `userAccountInformation` capability requirement, `E_ACCESSDENIED` behavior, C++/WinRT threading guidance, and **administrative policy** behavior (Group Policy / MDM can disable the Digital Safety age APIs or configure a default status/age group).
- **C++/WinRT and C#** usage examples.

Cross-references use full `https://learn.microsoft.com/uwp/api/...` URLs to guarantee link validation passes.

## Files added

- `windows.system/user_getageverificationstatusasync.md` (`M:Windows.System.User.GetAgeVerificationStatusAsync`)
- `windows.system/user_getuseragerangeasync.md` (`M:Windows.System.User.GetUserAgeRangeAsync`)

No TOC, metadata, or other files were changed. Filenames intentionally omit a numeric hash suffix since the build merges by `-api-id`, not filename.