### PR TITLE
Document HighContrastChanged behavior in WinUI 3

### DIFF
--- a/windows.ui.viewmanagement/accessibilitysettings_highcontrastchanged.md
+++ b/windows.ui.viewmanagement/accessibilitysettings_highcontrastchanged.md
@@ -14,6 +14,11 @@ Occurs when the system high contrast feature turns on or off.
 
 ## -remarks
 
+> [!WARNING]
+> This event relies on **CoreWindow**, which isn't available in WinUI 3 desktop apps. To detect High Contrast changes in a WinUI 3 app, use the [ThemeSettings.Changed](/windows/windows-app-sdk/api/winrt/microsoft.ui.system.themesettings.changed) event. Create a **ThemeSettings** object for your app window by calling [ThemeSettings.CreateForWindowId](/windows/windows-app-sdk/api/winrt/microsoft.ui.system.themesettings.createforwindowid), and retain a reference to the object for as long as you want to receive change notifications.
+
 ## -examples
 
 ## -see-also
+
+- [Mapping UWP APIs to the Windows App SDK](/windows/apps/windows-app-sdk/migrate-to-windows-app-sdk/api-mapping-table)


### PR DESCRIPTION
## Summary

- explain that `AccessibilitySettings.HighContrastChanged` relies on `CoreWindow` and is not supported in WinUI 3 desktop apps
- direct WinUI 3 developers to `ThemeSettings.Changed`
- document the `CreateForWindowId` and object-lifetime requirements
- link the Windows App SDK API mapping guidance

## Affected pages

- https://learn.microsoft.com/uwp/api/windows.ui.viewmanagement.accessibilitysettings.highcontrastchanged
- https://learn.microsoft.com/windows/apps/windows-app-sdk/migrate-to-windows-app-sdk/api-mapping-table

## Related PR

- https://github.com/MicrosoftDocs/windows-dev-docs-pr/pull/7289

This supersedes #2491 with wording aligned to the current Windows App SDK `ThemeSettings` specification and reference documentation.