### PR TITLE
Clarify Symbol enum values vs. Segoe MDL2 glyph code points (refs #2363)

### DIFF
--- a/windows.ui.xaml.controls/symbol.md
+++ b/windows.ui.xaml.controls/symbol.md
@@ -12,6 +12,25 @@ public enum Windows.UI.Xaml.Controls.Symbol : int
 ## -description
 Defines constants that specify a glyph from the **Segoe MDL2 Assets** font to use as the content of a [SymbolIcon](symbolicon.md).
 
+> [!IMPORTANT]
+> The numeric value shown for each constant is the **enum member value**, not necessarily the recommended font glyph code point for that icon. For example, `Setting` has the value 57621 (0xE115), but the maintained icon catalogs recommend the code point **E713** for the settings glyph.
+>
+> Some legacy code points in the E0xx–E5xx range can render as garbled characters in certain contexts, such as CJK locales, and are not recommended for direct use. Prefer referencing a glyph by its `Symbol` name, or use a maintained code point from the catalogs below.
+>
+> To reference a glyph by name with a [SymbolIcon](symbolicon.md):
+>
+> ```xaml
+> <SymbolIcon Symbol="Setting"/>
+> ```
+>
+> To use a maintained code point directly with a [FontIcon](fonticon.md):
+>
+> ```xaml
+> <FontIcon FontFamily="Segoe MDL2 Assets" Glyph="&#xE713;"/>
+> ```
+>
+> For the current, maintained glyph catalogs, see [Segoe Fluent Icons font](/windows/apps/design/style/segoe-fluent-icons-font) and [Segoe MDL2 Assets](/windows/apps/design/style/segoe-ui-symbol-font).
+
 
 
 ## -xaml-syntax
@@ -87,6 +106,8 @@ E114 <img alt="Camera icon" src="images/segoe-mdl/e114.png" />
 
 ### -field Setting:57621
 E115 <img alt="Setting icon" src="images/segoe-mdl/e115.png" />
+
+The enum member value is 57621 (0xE115). The maintained font catalogs recommend the code point **E713** for the settings glyph. To reference the glyph code point directly, use `<FontIcon FontFamily="Segoe MDL2 Assets" Glyph="&#xE713;"/>`. Referencing `Symbol="Setting"` in a [SymbolIcon](symbolicon.md) resolves the correct glyph automatically.
 
 ### -field Video:57622
 E116 <img alt="Video icon" src="images/segoe-mdl/e116.png" />
@@ -635,7 +656,7 @@ If you would like to use a glyph from the **Segoe MDL2 Assets** font that is not
 ## -examples
 
 ## -see-also
-[Guidelines for Segoe MDL2 icons](/windows/uwp/style/segoe-ui-symbol-font), [Quickstart: Adding app bar buttons (Windows 8)](/previous-versions/windows/apps/jj662743(v=win.10))
+[Guidelines for Segoe MDL2 icons](/windows/uwp/style/segoe-ui-symbol-font), [Segoe Fluent Icons font](/windows/apps/design/style/segoe-fluent-icons-font), [Quickstart: Adding app bar buttons (Windows 8)](/previous-versions/windows/apps/jj662743(v=win.10))
 
 
 


### PR DESCRIPTION
## Summary

Addresses issue #2363. The `Windows.UI.Xaml.Controls.Symbol` enum page conflated two different things: each enum member's numeric **value** (e.g. `Setting = 57621` / `0xE115`) and the recommended font **glyph code point** for that icon (e.g. `E713` for the settings glyph). This PR clarifies that distinction without changing any enum data.

## What changed

Focused edits to `windows.ui.xaml.controls/symbol.md` only:

- **`## -description`** — added a prominent `> [!IMPORTANT]` alert explaining that the numeric constant is the enum member value, not necessarily the recommended glyph code point; giving the concrete `Setting` example (57621 / 0xE115 vs. recommended code point E713); noting that legacy E0xx–E5xx code points can render as garbled characters in some contexts (e.g. CJK locales) and aren't recommended for direct use; and showing both reference approaches, plus links to the maintained catalogs.
- **`Setting` field** — added a clarifying paragraph after the existing (unchanged) value/image lines.
- **`## -see-also`** — added a link to the maintained [Segoe Fluent Icons font](/windows/apps/design/style/segoe-fluent-icons-font) catalog, keeping existing links.

## How each approach works

Reference a glyph by name (resolves the correct glyph automatically):

```xaml
<SymbolIcon Symbol="Setting"/>
```

Use a maintained code point directly:

```xaml
<FontIcon FontFamily="Segoe MDL2 Assets" Glyph="&#xE713;"/>
```

## Non-goals / guarantees

- **No enum members were renumbered, removed, or reordered.** All 197 `### -field` lines are byte-for-byte unchanged, including `Setting:57621` and its `E115` image line.
- No claim is made that Windows App SDK 1.5 (or any version) changed UWP behavior — this is the UWP reference page.

Refs #2363. The issue should remain open until this correction is published.